### PR TITLE
Fixed deps and Rand usage for tests and benchmarks

### DIFF
--- a/coaster-blas/Cargo.toml
+++ b/coaster-blas/Cargo.toml
@@ -29,6 +29,7 @@ clippy = { version = "0.0.302", optional = true }
 [dev-dependencies]
 
 rand = "0.7"
+rblas = { version = "0.0.13" } # Needed for benchmarking
 
 [features]
 default = ["native", "cuda"]

--- a/coaster-blas/benches/rblas_overhead.rs
+++ b/coaster-blas/benches/rblas_overhead.rs
@@ -11,6 +11,7 @@ use crate::co::prelude::*;
 use crate::co_blas::plugin::*;
 
 use rand::{thread_rng, Rng};
+use rand::distributions::Standard;
 
 fn backend() -> Backend<Native> {
     Backend::<Native>::default().unwrap()
@@ -18,28 +19,28 @@ fn backend() -> Backend<Native> {
 
 fn bench_dot_rblas(b: &mut Bencher, n: usize) {
     let mut rng = thread_rng();
-    let slice_a = rng.gen_iter::<f32>().take(n).collect::<Vec<f32>>();
-    let slice_b = rng.gen_iter::<f32>().take(n).collect::<Vec<f32>>();
+    let slice_a: Vec<f32> = rng.sample_iter(Standard).take(n).collect();
+    let slice_b: Vec<f32> = rng.sample_iter(Standard).take(n).collect();
 
     b.iter(|| {
-        let res = rblas::Dot::dot(&slice_a, &slice_b);
+        let res = rblas::Dot::dot(slice_a.as_slice(), slice_b.as_slice());
         test::black_box(res);
     });
 }
 
 fn bench_dot_coaster(b: &mut Bencher, n: usize) {
     let mut rng = thread_rng();
-    let slice_a = rng.gen_iter::<f32>().take(n).collect::<Vec<f32>>();
-    let slice_b = rng.gen_iter::<f32>().take(n).collect::<Vec<f32>>();
+    let slice_a: Vec<f32> = rng.sample_iter(Standard).take(n).collect();
+    let slice_b: Vec<f32> = rng.sample_iter(Standard).take(n).collect();
 
     let backend = backend();
     let shared_a = &mut SharedTensor::<f32>::new(&[n]);
     let shared_b = &mut SharedTensor::<f32>::new(&[n]);
     let shared_res = &mut SharedTensor::<f32>::new(&[1]);
     shared_a.write_only(backend.device()).unwrap()
-        .as_mut_slice().clone_from_slice(&slice_a);
+        .as_mut_slice().clone_from_slice(slice_a.as_slice());
     shared_b.write_only(backend.device()).unwrap()
-        .as_mut_slice().clone_from_slice(&slice_b);
+        .as_mut_slice().clone_from_slice(slice_b.as_slice());
     let _ = backend.dot(shared_a, shared_b, shared_res);
 
     b.iter(|| backend.dot(shared_a, shared_b, shared_res).unwrap());

--- a/coaster-nn/src/tests/mod.rs
+++ b/coaster-nn/src/tests/mod.rs
@@ -9,8 +9,7 @@
 use std;
 use std::fmt;
 
-use rand::thread_rng;
-use rand::distributions::{range, IndependentSample, Range};
+use rand::{thread_rng, Rng};
 
 use crate::co::prelude::*;
 use crate::co::plugin::numeric_helpers::{cast, NumCast};
@@ -79,7 +78,7 @@ pub fn filled_tensor<T,F>(backend: &Backend<F>, dims: &[usize], data: &[f64]) ->
 // verification or cross tests (Native <-> Cuda), but they aren't implemented
 // yet.
 pub fn uniformly_random_tensor<T,F>(_backend: &Backend<F>, dims: &[usize], low: T, high: T) -> SharedTensor<T>
-    where T: Copy + PartialEq + PartialOrd + range::SampleRange,
+    where T: Copy + PartialEq + PartialOrd + rand::distributions::uniform::SampleUniform,
           F: IFramework,
           Backend<F>: IBackend {
 
@@ -92,9 +91,8 @@ pub fn uniformly_random_tensor<T,F>(_backend: &Backend<F>, dims: &[usize], low: 
             let mem_slice = mem.as_mut_slice::<T>();
 
             let mut rng = thread_rng();
-            let distr = Range::new(low, high);
             for x in mem_slice {
-                *x = distr.ind_sample(&mut rng);
+                *x = Rng::gen_range(&mut rng, low, high);
             }
         }
   // not functional since, PartialEq has yet to be implemented for Device


### PR DESCRIPTION
Fixed the benchmark tests and the usage of the `rand` module as much as
possible without CUDA.