### PR TITLE
Replaced c_int with u32

### DIFF
--- a/rust-blas/src/math/bandmat.rs
+++ b/rust-blas/src/math/bandmat.rs
@@ -5,7 +5,6 @@ use crate::math::Mat;
 use crate::matrix::BandMatrix;
 use crate::vector::ops::Copy;
 use crate::Matrix;
-use libc::c_int;
 use num::traits::NumCast;
 use std::fmt;
 use std::iter::repeat;
@@ -16,13 +15,13 @@ use std::slice;
 pub struct BandMat<T> {
     rows: usize,
     cols: usize,
-    sub_diagonals: c_int,
-    sup_diagonals: c_int,
+    sub_diagonals: u32,
+    sup_diagonals: u32,
     data: Vec<T>,
 }
 
 impl<T> BandMat<T> {
-    pub fn new(n: usize, m: usize, sub: c_int, sup: c_int) -> BandMat<T> {
+    pub fn new(n: usize, m: usize, sub: u32, sup: u32) -> BandMat<T> {
         let len = n * m;
         let mut data = Vec::with_capacity(len);
         unsafe {
@@ -51,10 +50,10 @@ impl<T> BandMat<T> {
         self.cols = n;
     }
 
-    pub unsafe fn set_sub_diagonals(&mut self, n: c_int) {
+    pub unsafe fn set_sub_diagonals(&mut self, n: u32) {
         self.sub_diagonals = n;
     }
-    pub unsafe fn set_sup_diagonals(&mut self, n: c_int) {
+    pub unsafe fn set_sup_diagonals(&mut self, n: u32) {
         self.sup_diagonals = n;
     }
 
@@ -62,11 +61,7 @@ impl<T> BandMat<T> {
         self.data.push(val);
     }
 
-    pub unsafe fn from_matrix(
-        mut mat: Mat<T>,
-        sub_diagonals: c_int,
-        sup_diagonals: c_int,
-    ) -> BandMat<T> {
+    pub unsafe fn from_matrix(mut mat: Mat<T>, sub_diagonals: u32, sup_diagonals: u32) -> BandMat<T> {
         let data = mat.as_mut_ptr();
         let length = mat.cols() * mat.rows();
         BandMat {
@@ -85,8 +80,8 @@ impl<T: Clone> BandMat<T> {
             rows: n,
             cols: m,
             data: repeat(value).take(n * m).collect(),
-            sub_diagonals: n as c_int,
-            sup_diagonals: m as c_int,
+            sub_diagonals: n as u32,
+            sup_diagonals: m as u32,
         }
     }
 }
@@ -125,13 +120,13 @@ impl<T: fmt::Display> fmt::Display for BandMat<T> {
 }
 
 impl<T> Matrix<T> for BandMat<T> {
-    fn rows(&self) -> i32 {
-        let n: Option<i32> = NumCast::from(self.rows);
+    fn rows(&self) -> u32 {
+        let n: Option<u32> = NumCast::from(self.rows);
         n.unwrap()
     }
 
-    fn cols(&self) -> i32 {
-        let n: Option<i32> = NumCast::from(self.cols);
+    fn cols(&self) -> u32 {
+        let n: Option<u32> = NumCast::from(self.cols);
         n.unwrap()
     }
 
@@ -145,11 +140,11 @@ impl<T> Matrix<T> for BandMat<T> {
 }
 
 impl<T> BandMatrix<T> for BandMat<T> {
-    fn sub_diagonals(&self) -> i32 {
+    fn sub_diagonals(&self) -> u32 {
         self.sub_diagonals
     }
 
-    fn sup_diagonals(&self) -> i32 {
+    fn sup_diagonals(&self) -> u32 {
         self.sup_diagonals
     }
 
@@ -167,8 +162,8 @@ where
         let m = a.cols() as usize;
         let len = n * m;
 
-        let sub = a.sub_diagonals() as c_int;
-        let sup = a.sup_diagonals() as c_int;
+        let sub = a.sub_diagonals() as u32;
+        let sup = a.sup_diagonals() as u32;
 
         let mut result = BandMat {
             rows: n,

--- a/rust-blas/src/math/bandmat.rs
+++ b/rust-blas/src/math/bandmat.rs
@@ -61,7 +61,11 @@ impl<T> BandMat<T> {
         self.data.push(val);
     }
 
-    pub unsafe fn from_matrix(mut mat: Mat<T>, sub_diagonals: u32, sup_diagonals: u32) -> BandMat<T> {
+    pub unsafe fn from_matrix(
+        mut mat: Mat<T>,
+        sub_diagonals: u32,
+        sup_diagonals: u32,
+    ) -> BandMat<T> {
         let data = mat.as_mut_ptr();
         let length = mat.cols() * mat.rows();
         BandMat {

--- a/rust-blas/src/math/mat.rs
+++ b/rust-blas/src/math/mat.rs
@@ -95,13 +95,13 @@ impl<T: fmt::Display> fmt::Display for Mat<T> {
 }
 
 impl<T> Matrix<T> for Mat<T> {
-    fn rows(&self) -> i32 {
-        let n: Option<i32> = NumCast::from(self.rows);
+    fn rows(&self) -> u32 {
+        let n: Option<u32> = NumCast::from(self.rows);
         n.unwrap()
     }
 
-    fn cols(&self) -> i32 {
-        let n: Option<i32> = NumCast::from(self.cols);
+    fn cols(&self) -> u32 {
+        let n: Option<u32> = NumCast::from(self.cols);
         n.unwrap()
     }
 

--- a/rust-blas/src/matrix/ll.rs
+++ b/rust-blas/src/matrix/ll.rs
@@ -5,14 +5,8 @@
 //! Bindings for matrix functions.
 
 pub mod cblas_s {
-    use libc::{c_float};
-    use crate::attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-        Side,
-    };
+    use crate::attribute::{Diagonal, Order, Side, Symmetry, Transpose};
+    use libc::c_float;
 
     pub use self::cblas_sgemm as gemm;
     pub use self::cblas_ssymm as symm;
@@ -21,25 +15,100 @@ pub mod cblas_s {
     pub use self::cblas_strmm as trmm;
     pub use self::cblas_strsm as strsm;
 
-    extern {
-        pub fn cblas_sgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
-        pub fn cblas_ssymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
-        pub fn cblas_strmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *mut c_float,  ldb: u32);
-        pub fn cblas_strsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *mut c_float,  ldb: u32);
-        pub fn cblas_ssyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
-        pub fn cblas_ssyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
+    extern "C" {
+        pub fn cblas_sgemm(
+            order: Order,
+            trans_a: Transpose,
+            trans_b: Transpose,
+            m: u32,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *const c_float,
+            ldb: u32,
+            beta: c_float,
+            c: *mut c_float,
+            ldc: u32,
+        );
+        pub fn cblas_ssymm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *const c_float,
+            ldb: u32,
+            beta: c_float,
+            c: *mut c_float,
+            ldc: u32,
+        );
+        pub fn cblas_strmm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *mut c_float,
+            ldb: u32,
+        );
+        pub fn cblas_strsm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *mut c_float,
+            ldb: u32,
+        );
+        pub fn cblas_ssyrk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            beta: c_float,
+            c: *mut c_float,
+            ldc: u32,
+        );
+        pub fn cblas_ssyr2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *const c_float,
+            ldb: u32,
+            beta: c_float,
+            c: *mut c_float,
+            ldc: u32,
+        );
     }
 }
 
 pub mod cblas_d {
-    use libc::{c_double};
-    use crate::attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-        Side,
-    };
+    use crate::attribute::{Diagonal, Order, Side, Symmetry, Transpose};
+    use libc::c_double;
 
     pub use self::cblas_dgemm as gemm;
     pub use self::cblas_dsymm as symm;
@@ -48,25 +117,100 @@ pub mod cblas_d {
     pub use self::cblas_dtrmm as trmm;
     pub use self::cblas_dtrsm as strsm;
 
-    extern {
-        pub fn cblas_dgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
-        pub fn cblas_dsymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
-        pub fn cblas_dtrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *mut c_double,  ldb: u32);
-        pub fn cblas_dtrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *mut c_double,  ldb: u32);
-        pub fn cblas_dsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
-        pub fn cblas_dsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
+    extern "C" {
+        pub fn cblas_dgemm(
+            order: Order,
+            trans_a: Transpose,
+            trans_b: Transpose,
+            m: u32,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *const c_double,
+            ldb: u32,
+            beta: c_double,
+            c: *mut c_double,
+            ldc: u32,
+        );
+        pub fn cblas_dsymm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *const c_double,
+            ldb: u32,
+            beta: c_double,
+            c: *mut c_double,
+            ldc: u32,
+        );
+        pub fn cblas_dtrmm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *mut c_double,
+            ldb: u32,
+        );
+        pub fn cblas_dtrsm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *mut c_double,
+            ldb: u32,
+        );
+        pub fn cblas_dsyrk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            beta: c_double,
+            c: *mut c_double,
+            ldc: u32,
+        );
+        pub fn cblas_dsyr2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *const c_double,
+            ldb: u32,
+            beta: c_double,
+            c: *mut c_double,
+            ldc: u32,
+        );
     }
 }
 
 pub mod cblas_c {
+    use crate::attribute::{Diagonal, Order, Side, Symmetry, Transpose};
     use libc::{c_float, c_void};
-    use crate::attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-        Side,
-    };
 
     pub use self::cblas_cgemm as gemm;
     pub use self::cblas_chemm as hemm;
@@ -78,28 +222,143 @@ pub mod cblas_c {
     pub use self::cblas_ctrmm as trmm;
     pub use self::cblas_ctrsm as trsm;
 
-    extern {
-        pub fn cblas_cgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_csymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_chemm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_ctrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
-        pub fn cblas_ctrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
-        pub fn cblas_cherk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,  a: *const c_void, lda: u32, beta: c_float,  c: *mut c_void, ldc: u32);
-        pub fn cblas_cher2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void, lda: u32, b: *const c_void, ldb: u32, beta: c_float,  c: *mut c_void, ldc: u32);
-        pub fn cblas_csyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_csyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+    extern "C" {
+        pub fn cblas_cgemm(
+            order: Order,
+            trans_a: Transpose,
+            trans_b: Transpose,
+            m: u32,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_csymm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_chemm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_ctrmm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *mut c_void,
+            ldb: u32,
+        );
+        pub fn cblas_ctrsm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *mut c_void,
+            ldb: u32,
+        );
+        pub fn cblas_cherk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_void,
+            lda: u32,
+            beta: c_float,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_cher2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: c_float,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_csyrk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_csyr2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
     }
 }
 
 pub mod cblas_z {
+    use crate::attribute::{Diagonal, Order, Side, Symmetry, Transpose};
     use libc::{c_double, c_void};
-    use crate::attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-        Side,
-    };
 
     pub use self::cblas_zgemm as gemm;
     pub use self::cblas_zhemm as hemm;
@@ -111,15 +370,136 @@ pub mod cblas_z {
     pub use self::cblas_ztrmm as trmm;
     pub use self::cblas_ztrsm as trsm;
 
-    extern {
-        pub fn cblas_zgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_zsymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_zhemm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_ztrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
-        pub fn cblas_ztrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
-        pub fn cblas_zherk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double, a: *const c_void, lda: u32, beta: c_double, c: *mut c_void, ldc: u32);
-        pub fn cblas_zher2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void, lda: u32, b: *const c_void, ldb: u32, beta: c_double, c: *mut c_void, ldc: u32);
-        pub fn cblas_zsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_zsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+    extern "C" {
+        pub fn cblas_zgemm(
+            order: Order,
+            trans_a: Transpose,
+            trans_b: Transpose,
+            m: u32,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zsymm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zhemm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_ztrmm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *mut c_void,
+            ldb: u32,
+        );
+        pub fn cblas_ztrsm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *mut c_void,
+            ldb: u32,
+        );
+        pub fn cblas_zherk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_void,
+            lda: u32,
+            beta: c_double,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zher2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: c_double,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zsyrk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zsyr2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
     }
 }

--- a/rust-blas/src/matrix/ll.rs
+++ b/rust-blas/src/matrix/ll.rs
@@ -5,8 +5,14 @@
 //! Bindings for matrix functions.
 
 pub mod cblas_s {
-    use crate::attribute::{Diagonal, Order, Side, Symmetry, Transpose};
-    use libc::{c_float, c_int};
+    use libc::{c_float};
+    use crate::attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+        Side,
+    };
 
     pub use self::cblas_sgemm as gemm;
     pub use self::cblas_ssymm as symm;
@@ -15,100 +21,25 @@ pub mod cblas_s {
     pub use self::cblas_strmm as trmm;
     pub use self::cblas_strsm as strsm;
 
-    extern "C" {
-        pub fn cblas_sgemm(
-            order: Order,
-            trans_a: Transpose,
-            trans_b: Transpose,
-            m: c_int,
-            n: c_int,
-            k: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            b: *const c_float,
-            ldb: c_int,
-            beta: c_float,
-            c: *mut c_float,
-            ldc: c_int,
-        );
-        pub fn cblas_ssymm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            m: c_int,
-            n: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            b: *const c_float,
-            ldb: c_int,
-            beta: c_float,
-            c: *mut c_float,
-            ldc: c_int,
-        );
-        pub fn cblas_strmm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            m: c_int,
-            n: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            b: *mut c_float,
-            ldb: c_int,
-        );
-        pub fn cblas_strsm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            m: c_int,
-            n: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            b: *mut c_float,
-            ldb: c_int,
-        );
-        pub fn cblas_ssyrk(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            beta: c_float,
-            c: *mut c_float,
-            ldc: c_int,
-        );
-        pub fn cblas_ssyr2k(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            b: *const c_float,
-            ldb: c_int,
-            beta: c_float,
-            c: *mut c_float,
-            ldc: c_int,
-        );
+    extern {
+        pub fn cblas_sgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
+        pub fn cblas_ssymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
+        pub fn cblas_strmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *mut c_float,  ldb: u32);
+        pub fn cblas_strsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *mut c_float,  ldb: u32);
+        pub fn cblas_ssyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
+        pub fn cblas_ssyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
     }
 }
 
 pub mod cblas_d {
-    use crate::attribute::{Diagonal, Order, Side, Symmetry, Transpose};
-    use libc::{c_double, c_int};
+    use libc::{c_double};
+    use crate::attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+        Side,
+    };
 
     pub use self::cblas_dgemm as gemm;
     pub use self::cblas_dsymm as symm;
@@ -117,100 +48,25 @@ pub mod cblas_d {
     pub use self::cblas_dtrmm as trmm;
     pub use self::cblas_dtrsm as strsm;
 
-    extern "C" {
-        pub fn cblas_dgemm(
-            order: Order,
-            trans_a: Transpose,
-            trans_b: Transpose,
-            m: c_int,
-            n: c_int,
-            k: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            b: *const c_double,
-            ldb: c_int,
-            beta: c_double,
-            c: *mut c_double,
-            ldc: c_int,
-        );
-        pub fn cblas_dsymm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            m: c_int,
-            n: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            b: *const c_double,
-            ldb: c_int,
-            beta: c_double,
-            c: *mut c_double,
-            ldc: c_int,
-        );
-        pub fn cblas_dtrmm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            m: c_int,
-            n: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            b: *mut c_double,
-            ldb: c_int,
-        );
-        pub fn cblas_dtrsm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            m: c_int,
-            n: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            b: *mut c_double,
-            ldb: c_int,
-        );
-        pub fn cblas_dsyrk(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            beta: c_double,
-            c: *mut c_double,
-            ldc: c_int,
-        );
-        pub fn cblas_dsyr2k(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            b: *const c_double,
-            ldb: c_int,
-            beta: c_double,
-            c: *mut c_double,
-            ldc: c_int,
-        );
+    extern {
+        pub fn cblas_dgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
+        pub fn cblas_dsymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
+        pub fn cblas_dtrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *mut c_double,  ldb: u32);
+        pub fn cblas_dtrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *mut c_double,  ldb: u32);
+        pub fn cblas_dsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
+        pub fn cblas_dsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
     }
 }
 
 pub mod cblas_c {
-    use crate::attribute::{Diagonal, Order, Side, Symmetry, Transpose};
-    use libc::{c_float, c_int, c_void};
+    use libc::{c_float, c_void};
+    use crate::attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+        Side,
+    };
 
     pub use self::cblas_cgemm as gemm;
     pub use self::cblas_chemm as hemm;
@@ -222,143 +78,28 @@ pub mod cblas_c {
     pub use self::cblas_ctrmm as trmm;
     pub use self::cblas_ctrsm as trsm;
 
-    extern "C" {
-        pub fn cblas_cgemm(
-            order: Order,
-            trans_a: Transpose,
-            trans_b: Transpose,
-            m: c_int,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_csymm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_chemm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_ctrmm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *mut c_void,
-            ldb: c_int,
-        );
-        pub fn cblas_ctrsm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *mut c_void,
-            ldb: c_int,
-        );
-        pub fn cblas_cherk(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: c_float,
-            a: *const c_void,
-            lda: c_int,
-            beta: c_float,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_cher2k(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: c_float,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_csyrk(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_csyr2k(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
+    extern {
+        pub fn cblas_cgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_csymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_chemm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_ctrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
+        pub fn cblas_ctrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
+        pub fn cblas_cherk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,  a: *const c_void, lda: u32, beta: c_float,  c: *mut c_void, ldc: u32);
+        pub fn cblas_cher2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void, lda: u32, b: *const c_void, ldb: u32, beta: c_float,  c: *mut c_void, ldc: u32);
+        pub fn cblas_csyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_csyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
     }
 }
 
 pub mod cblas_z {
-    use crate::attribute::{Diagonal, Order, Side, Symmetry, Transpose};
-    use libc::{c_double, c_int, c_void};
+    use libc::{c_double, c_void};
+    use crate::attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+        Side,
+    };
 
     pub use self::cblas_zgemm as gemm;
     pub use self::cblas_zhemm as hemm;
@@ -370,136 +111,15 @@ pub mod cblas_z {
     pub use self::cblas_ztrmm as trmm;
     pub use self::cblas_ztrsm as trsm;
 
-    extern "C" {
-        pub fn cblas_zgemm(
-            order: Order,
-            trans_a: Transpose,
-            trans_b: Transpose,
-            m: c_int,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_zsymm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_zhemm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_ztrmm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *mut c_void,
-            ldb: c_int,
-        );
-        pub fn cblas_ztrsm(
-            order: Order,
-            side: Side,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *mut c_void,
-            ldb: c_int,
-        );
-        pub fn cblas_zherk(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: c_double,
-            a: *const c_void,
-            lda: c_int,
-            beta: c_double,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_zher2k(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: c_double,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_zsyrk(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
-        pub fn cblas_zsyr2k(
-            order: Order,
-            sym: Symmetry,
-            Trans: Transpose,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            b: *const c_void,
-            ldb: c_int,
-            beta: *const c_void,
-            c: *mut c_void,
-            ldc: c_int,
-        );
+    extern {
+        pub fn cblas_zgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_zsymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_zhemm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_ztrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
+        pub fn cblas_ztrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
+        pub fn cblas_zherk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double, a: *const c_void, lda: u32, beta: c_double, c: *mut c_void, ldc: u32);
+        pub fn cblas_zher2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void, lda: u32, b: *const c_void, ldb: u32, beta: c_double, c: *mut c_void, ldc: u32);
+        pub fn cblas_zsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_zsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
     }
 }

--- a/rust-blas/src/matrix/mod.rs
+++ b/rust-blas/src/matrix/mod.rs
@@ -3,8 +3,9 @@
 // license that can be found in the LICENSE file.
 
 //! Matrix operations.
-use crate::attribute::Order;
-use libc::c_int;
+use crate::attribute::{
+    Order,
+};
 
 pub mod ll;
 pub mod ops;
@@ -13,7 +14,7 @@ pub mod ops;
 pub trait Matrix<T> {
     /// The leading dimension of the matrix. Defaults to `cols` for `RowMajor`
     /// order and 'rows' for `ColMajor` order.
-    fn lead_dim(&self) -> c_int {
+    fn lead_dim(&self) -> u32 {
         match self.order() {
             Order::RowMajor => self.cols(),
             Order::ColMajor => self.rows(),
@@ -24,9 +25,9 @@ pub trait Matrix<T> {
         Order::RowMajor
     }
     /// Returns the number of rows.
-    fn rows(&self) -> c_int;
+    fn rows(&self) -> u32;
     /// Returns the number of columns.
-    fn cols(&self) -> c_int;
+    fn cols(&self) -> u32;
     /// An unsafe pointer to a contiguous block of memory.
     fn as_ptr(&self) -> *const T;
     /// An unsafe pointer to a contiguous block of memory.
@@ -34,8 +35,8 @@ pub trait Matrix<T> {
 }
 
 pub trait BandMatrix<T>: Matrix<T> {
-    fn sub_diagonals(&self) -> c_int;
-    fn sup_diagonals(&self) -> c_int;
+    fn sub_diagonals(&self) -> u32;
+    fn sup_diagonals(&self) -> u32;
 
     fn as_matrix(&self) -> &dyn Matrix<T>;
 }
@@ -43,16 +44,15 @@ pub trait BandMatrix<T>: Matrix<T> {
 #[cfg(test)]
 pub mod tests {
     use crate::Matrix;
-    use libc::c_int;
 
-    pub struct M<T>(pub c_int, pub c_int, pub Vec<T>);
+    pub struct M<T>(pub u32, pub u32, pub Vec<T>);
 
     impl<T> Matrix<T> for M<T> {
-        fn rows(&self) -> c_int {
+        fn rows(&self) -> u32 {
             self.0
         }
 
-        fn cols(&self) -> c_int {
+        fn cols(&self) -> u32 {
             self.1
         }
 

--- a/rust-blas/src/matrix/mod.rs
+++ b/rust-blas/src/matrix/mod.rs
@@ -3,9 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //! Matrix operations.
-use crate::attribute::{
-    Order,
-};
+use crate::attribute::Order;
 
 pub mod ll;
 pub mod ops;

--- a/rust-blas/src/matrix_vector/ll.rs
+++ b/rust-blas/src/matrix_vector/ll.rs
@@ -5,8 +5,13 @@
 //! Bindings for matrix-vector functions.
 
 pub mod cblas_s {
-    use crate::attribute::{Diagonal, Order, Symmetry, Transpose};
-    use libc::{c_float, c_int};
+    use libc::{c_float};
+    use crate::attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+    };
 
     pub use self::cblas_sgbmv as gbmv;
     pub use self::cblas_sgemv as gemv;
@@ -25,200 +30,34 @@ pub mod cblas_s {
     pub use self::cblas_strmv as trmv;
     pub use self::cblas_strsv as trsv;
 
-    extern "C" {
-        pub fn cblas_sgemv(
-            order: Order,
-            trans: Transpose,
-            m: c_int,
-            n: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            x: *const c_float,
-            inc_x: c_int,
-            beta: c_float,
-            y: *mut c_float,
-            inc_y: c_int,
-        );
-        pub fn cblas_ssymv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            x: *const c_float,
-            inc_x: c_int,
-            beta: c_float,
-            y: *mut c_float,
-            inc_y: c_int,
-        );
-        pub fn cblas_strmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_float,
-            lda: c_int,
-            x: *mut c_float,
-            inc_x: c_int,
-        );
-        pub fn cblas_strsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_float,
-            lda: c_int,
-            x: *mut c_float,
-            inc_x: c_int,
-        );
-        pub fn cblas_sger(
-            order: Order,
-            m: c_int,
-            n: c_int,
-            alpha: c_float,
-            x: *const c_float,
-            inc_x: c_int,
-            y: *const c_float,
-            inc_y: c_int,
-            a: *mut c_float,
-            lda: c_int,
-        );
-        pub fn cblas_ssyr(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_float,
-            x: *const c_float,
-            inc_x: c_int,
-            a: *mut c_float,
-            lda: c_int,
-        );
-        pub fn cblas_ssyr2(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_float,
-            x: *const c_float,
-            inc_x: c_int,
-            y: *const c_float,
-            inc_y: c_int,
-            a: *mut c_float,
-            lda: c_int,
-        );
-        pub fn cblas_sspmv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            x: *const c_float,
-            inc_x: c_int,
-            beta: c_float,
-            y: *mut c_float,
-            inc_y: c_int,
-        );
-        pub fn cblas_sgbmv(
-            order: Order,
-            trans: Transpose,
-            m: c_int,
-            n: c_int,
-            kl: c_int,
-            ku: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            x: *const c_float,
-            inc_x: c_int,
-            beta: c_float,
-            y: *mut c_float,
-            inc_y: c_int,
-        );
-        pub fn cblas_ssbmv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            k: c_int,
-            alpha: c_float,
-            a: *const c_float,
-            lda: c_int,
-            x: *const c_float,
-            inc_x: c_int,
-            beta: c_float,
-            y: *mut c_float,
-            inc_y: c_int,
-        );
-        pub fn cblas_stbmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            k: c_int,
-            a: *const c_float,
-            x: *mut c_float,
-            inc_x: c_int,
-        );
-        pub fn cblas_stbsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            k: c_int,
-            a: *const c_float,
-            x: *mut c_float,
-            inc_x: c_int,
-        );
-        pub fn cblas_stpmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_float,
-            x: *mut c_float,
-            inc_x: c_int,
-        );
-        pub fn cblas_stpsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_float,
-            x: *mut c_float,
-            inc_x: c_int,
-        );
-        pub fn cblas_sspr(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_float,
-            x: *const c_float,
-            inc_x: c_int,
-            a: *mut c_float,
-        );
-        pub fn cblas_sspr2(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_float,
-            x: *const c_float,
-            inc_x: c_int,
-            y: *const c_float,
-            inc_y: c_int,
-            a: *mut c_float,
-        );
+    extern {
+        pub fn cblas_sgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_ssymv(order: Order, sym: Symmetry, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_strmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  lda: u32, x: *mut c_float,  inc_x: u32);
+        pub fn cblas_strsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  lda: u32, x: *mut c_float,  inc_x: u32);
+        pub fn cblas_sger (order: Order, m: u32, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float,  lda: u32);
+        pub fn cblas_ssyr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_float,  inc_x: u32, a: *mut c_float,  lda: u32);
+        pub fn cblas_ssyr2(order: Order, sym: Symmetry, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float,  lda: u32);
+        pub fn cblas_sspmv(order: Order, sym: Symmetry, n: u32, alpha: c_float,       a: *const c_float,  x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_sgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_ssbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_stbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
+        pub fn cblas_stbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
+        pub fn cblas_stpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
+        pub fn cblas_stpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
+        pub fn cblas_sspr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_float,  inc_x: u32, a: *mut c_float);
+        pub fn cblas_sspr2(order: Order, sym: Symmetry, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float);
     }
 }
 
 pub mod cblas_d {
-    use crate::attribute::{Diagonal, Order, Symmetry, Transpose};
-    use libc::{c_double, c_int};
+    use libc::{c_double};
+    use crate::attribute::{
+        Order,
+        Transpose,
+        Symmetry,
+        Diagonal,
+    };
 
     pub use self::cblas_dgbmv as gbmv;
     pub use self::cblas_dgemv as gemv;
@@ -237,200 +76,29 @@ pub mod cblas_d {
     pub use self::cblas_dtrmv as trmv;
     pub use self::cblas_dtrsv as trsv;
 
-    extern "C" {
-        pub fn cblas_dgemv(
-            order: Order,
-            trans: Transpose,
-            m: c_int,
-            n: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            x: *const c_double,
-            inc_x: c_int,
-            beta: c_double,
-            y: *mut c_double,
-            inc_y: c_int,
-        );
-        pub fn cblas_dsymv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            x: *const c_double,
-            inc_x: c_int,
-            beta: c_double,
-            y: *mut c_double,
-            inc_y: c_int,
-        );
-        pub fn cblas_dtrmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_double,
-            lda: c_int,
-            x: *mut c_double,
-            inc_x: c_int,
-        );
-        pub fn cblas_dtrsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_double,
-            lda: c_int,
-            x: *mut c_double,
-            inc_x: c_int,
-        );
-        pub fn cblas_dger(
-            order: Order,
-            m: c_int,
-            n: c_int,
-            alpha: c_double,
-            x: *const c_double,
-            inc_x: c_int,
-            y: *const c_double,
-            inc_y: c_int,
-            a: *mut c_double,
-            lda: c_int,
-        );
-        pub fn cblas_dsyr(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_double,
-            x: *const c_double,
-            inc_x: c_int,
-            a: *mut c_double,
-            lda: c_int,
-        );
-        pub fn cblas_dsyr2(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_double,
-            x: *const c_double,
-            inc_x: c_int,
-            y: *const c_double,
-            inc_y: c_int,
-            a: *mut c_double,
-            lda: c_int,
-        );
-        pub fn cblas_dspmv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            x: *const c_double,
-            inc_x: c_int,
-            beta: c_double,
-            y: *mut c_double,
-            inc_y: c_int,
-        );
-        pub fn cblas_dgbmv(
-            order: Order,
-            trans: Transpose,
-            m: c_int,
-            n: c_int,
-            kl: c_int,
-            ku: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            x: *const c_double,
-            inc_x: c_int,
-            beta: c_double,
-            y: *mut c_double,
-            inc_y: c_int,
-        );
-        pub fn cblas_dsbmv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            k: c_int,
-            alpha: c_double,
-            a: *const c_double,
-            lda: c_int,
-            x: *const c_double,
-            inc_x: c_int,
-            beta: c_double,
-            y: *mut c_double,
-            inc_y: c_int,
-        );
-        pub fn cblas_dtbmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            k: c_int,
-            a: *const c_double,
-            x: *mut c_double,
-            inc_x: c_int,
-        );
-        pub fn cblas_dtbsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            k: c_int,
-            a: *const c_double,
-            x: *mut c_double,
-            inc_x: c_int,
-        );
-        pub fn cblas_dtpmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_double,
-            x: *mut c_double,
-            inc_x: c_int,
-        );
-        pub fn cblas_dtpsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_double,
-            x: *mut c_double,
-            inc_x: c_int,
-        );
-        pub fn cblas_dspr(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_double,
-            x: *const c_double,
-            inc_x: c_int,
-            a: *mut c_double,
-        );
-        pub fn cblas_dspr2(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_double,
-            x: *const c_double,
-            inc_x: c_int,
-            y: *const c_double,
-            inc_y: c_int,
-            a: *mut c_double,
-        );
+    extern {
+        pub fn cblas_dgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dsymv(order: Order, sym: Symmetry, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dtrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  lda: u32, x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dtrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  lda: u32, x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dger (order: Order, m: u32, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double,  lda: u32);
+        pub fn cblas_dsyr(order: Order, sym: Symmetry, n: u32, alpha: c_double,  x: *const c_double,  inc_x: u32, a: *mut c_double,  lda: u32);
+        pub fn cblas_dsyr2(order: Order, sym: Symmetry, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double,  lda: u32);
+        pub fn cblas_dspmv(order: Order, sym: Symmetry, n: u32, alpha: c_double,       a: *const c_double,  x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dsbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dtbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dtbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dtpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dtpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dspr(order: Order, sym: Symmetry, n: u32, alpha: c_double,  x: *const c_double,  inc_x: u32, a: *mut c_double);
+        pub fn cblas_dspr2(order: Order, sym: Symmetry, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double);
     }
 }
 
 pub mod cblas_c {
     use crate::attribute::{Diagonal, Order, Symmetry, Transpose};
-    use libc::{c_float, c_int, c_void};
+    use libc::{c_float, c_void};
 
     pub use self::cblas_cgbmv as gbmv;
     pub use self::cblas_cgemv as gemv;
@@ -451,225 +119,31 @@ pub mod cblas_c {
     pub use self::cblas_ctrmv as trmv;
     pub use self::cblas_ctrsv as trsv;
 
-    extern "C" {
-        pub fn cblas_cgemv(
-            order: Order,
-            trans: Transpose,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_csymv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_chemv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_ctrmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_void,
-            lda: c_int,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_ctrsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_void,
-            lda: c_int,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_cgeru(
-            order: Order,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            a: *mut c_void,
-            lda: c_int,
-        );
-        pub fn cblas_cgerc(
-            order: Order,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            a: *mut c_void,
-            lda: c_int,
-        );
-        pub fn cblas_cher(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_float,
-            x: *const c_void,
-            inc_x: c_int,
-            a: *mut c_void,
-            lda: c_int,
-        );
-        pub fn cblas_cher2(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            a: *mut c_void,
-            lda: c_int,
-        );
-        pub fn cblas_cgbmv(
-            order: Order,
-            trans: Transpose,
-            m: c_int,
-            n: c_int,
-            kl: c_int,
-            ku: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_chbmv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_ctbmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            k: c_int,
-            a: *const c_void,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_ctbsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            k: c_int,
-            a: *const c_void,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_chpmv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_ctpmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_void,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_ctpsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_void,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_chpr(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_float,
-            x: *const c_void,
-            inc_x: c_int,
-            a: *mut c_void,
-        );
-        pub fn cblas_chpr2(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            a: *mut c_void,
-        );
+    extern {
+        pub fn cblas_cgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_csymv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_chemv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ctrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ctrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_cgeru(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_cgerc(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_cher(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_void,   inc_x: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_cher2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_cgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_chbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ctbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ctbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_chpmv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ctpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ctpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_chpr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_void,   inc_x: u32, a: *mut c_void);
+        pub fn cblas_chpr2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void);
     }
 }
 
 pub mod cblas_z {
     use crate::attribute::{Diagonal, Order, Symmetry, Transpose};
-    use libc::{c_double, c_int, c_void};
+    use libc::{c_double, c_void};
 
     pub use self::cblas_zgbmv as gbmv;
     pub use self::cblas_zgemv as gemv;
@@ -690,218 +164,24 @@ pub mod cblas_z {
     pub use self::cblas_ztrmv as trmv;
     pub use self::cblas_ztrsv as trsv;
 
-    extern "C" {
-        pub fn cblas_zgemv(
-            order: Order,
-            trans: Transpose,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_zsymv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_zhemv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_ztrmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_void,
-            lda: c_int,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_ztrsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_void,
-            lda: c_int,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_zgeru(
-            order: Order,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            a: *mut c_void,
-            lda: c_int,
-        );
-        pub fn cblas_zgerc(
-            order: Order,
-            m: c_int,
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            a: *mut c_void,
-            lda: c_int,
-        );
-        pub fn cblas_zher(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_double,
-            x: *const c_void,
-            inc_x: c_int,
-            a: *mut c_void,
-            lda: c_int,
-        );
-        pub fn cblas_zher2(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            a: *mut c_void,
-            lda: c_int,
-        );
-        pub fn cblas_zgbmv(
-            order: Order,
-            trans: Transpose,
-            m: c_int,
-            n: c_int,
-            kl: c_int,
-            ku: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_zhbmv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            k: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            lda: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_ztbmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            k: c_int,
-            a: *const c_void,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_ztbsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            k: c_int,
-            a: *const c_void,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_zhpmv(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            a: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            beta: *const c_void,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_ztpmv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_void,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_ztpsv(
-            order: Order,
-            sym: Symmetry,
-            trans: Transpose,
-            diag: Diagonal,
-            n: c_int,
-            a: *const c_void,
-            x: *mut c_void,
-            inc_x: c_int,
-        );
-        pub fn cblas_zhpr(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: c_double,
-            x: *const c_void,
-            inc_x: c_int,
-            a: *mut c_void,
-        );
-        pub fn cblas_zhpr2(
-            order: Order,
-            sym: Symmetry,
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            a: *mut c_void,
-        );
+    extern {
+        pub fn cblas_zgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zsymv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zhemv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ztrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ztrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zgeru(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_zgerc(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_zher(order: Order, sym: Symmetry, n: u32, alpha: c_double, x: *const c_void,   inc_x: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_zher2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_zgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zhbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ztbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ztbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zhpmv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ztpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ztpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zhpr(order: Order, sym: Symmetry, n: u32, alpha: c_double, x: *const c_void,   inc_x: u32, a: *mut c_void);
+        pub fn cblas_zhpr2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void);
     }
 }

--- a/rust-blas/src/matrix_vector/ll.rs
+++ b/rust-blas/src/matrix_vector/ll.rs
@@ -5,13 +5,8 @@
 //! Bindings for matrix-vector functions.
 
 pub mod cblas_s {
-    use libc::{c_float};
-    use crate::attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-    };
+    use crate::attribute::{Diagonal, Order, Symmetry, Transpose};
+    use libc::c_float;
 
     pub use self::cblas_sgbmv as gbmv;
     pub use self::cblas_sgemv as gemv;
@@ -30,34 +25,200 @@ pub mod cblas_s {
     pub use self::cblas_strmv as trmv;
     pub use self::cblas_strsv as trsv;
 
-    extern {
-        pub fn cblas_sgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_ssymv(order: Order, sym: Symmetry, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_strmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  lda: u32, x: *mut c_float,  inc_x: u32);
-        pub fn cblas_strsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  lda: u32, x: *mut c_float,  inc_x: u32);
-        pub fn cblas_sger (order: Order, m: u32, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float,  lda: u32);
-        pub fn cblas_ssyr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_float,  inc_x: u32, a: *mut c_float,  lda: u32);
-        pub fn cblas_ssyr2(order: Order, sym: Symmetry, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float,  lda: u32);
-        pub fn cblas_sspmv(order: Order, sym: Symmetry, n: u32, alpha: c_float,       a: *const c_float,  x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_sgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_ssbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_stbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
-        pub fn cblas_stbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
-        pub fn cblas_stpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
-        pub fn cblas_stpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
-        pub fn cblas_sspr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_float,  inc_x: u32, a: *mut c_float);
-        pub fn cblas_sspr2(order: Order, sym: Symmetry, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float);
+    extern "C" {
+        pub fn cblas_sgemv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_ssymv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_strmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_float,
+            lda: u32,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_strsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_float,
+            lda: u32,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_sger(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+            a: *mut c_float,
+            lda: u32,
+        );
+        pub fn cblas_ssyr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            a: *mut c_float,
+            lda: u32,
+        );
+        pub fn cblas_ssyr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+            a: *mut c_float,
+            lda: u32,
+        );
+        pub fn cblas_sspmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_sgbmv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            kl: u32,
+            ku: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_ssbmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_stbmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_float,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_stbsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_float,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_stpmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_float,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_stpsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_float,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_sspr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            a: *mut c_float,
+        );
+        pub fn cblas_sspr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+            a: *mut c_float,
+        );
     }
 }
 
 pub mod cblas_d {
-    use libc::{c_double};
-    use crate::attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-    };
+    use crate::attribute::{Diagonal, Order, Symmetry, Transpose};
+    use libc::c_double;
 
     pub use self::cblas_dgbmv as gbmv;
     pub use self::cblas_dgemv as gemv;
@@ -76,23 +237,194 @@ pub mod cblas_d {
     pub use self::cblas_dtrmv as trmv;
     pub use self::cblas_dtrsv as trsv;
 
-    extern {
-        pub fn cblas_dgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dsymv(order: Order, sym: Symmetry, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dtrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  lda: u32, x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dtrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  lda: u32, x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dger (order: Order, m: u32, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double,  lda: u32);
-        pub fn cblas_dsyr(order: Order, sym: Symmetry, n: u32, alpha: c_double,  x: *const c_double,  inc_x: u32, a: *mut c_double,  lda: u32);
-        pub fn cblas_dsyr2(order: Order, sym: Symmetry, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double,  lda: u32);
-        pub fn cblas_dspmv(order: Order, sym: Symmetry, n: u32, alpha: c_double,       a: *const c_double,  x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dsbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dtbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dtbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dtpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dtpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dspr(order: Order, sym: Symmetry, n: u32, alpha: c_double,  x: *const c_double,  inc_x: u32, a: *mut c_double);
-        pub fn cblas_dspr2(order: Order, sym: Symmetry, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double);
+    extern "C" {
+        pub fn cblas_dgemv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dsymv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dtrmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_double,
+            lda: u32,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dtrsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_double,
+            lda: u32,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dger(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            y: *const c_double,
+            inc_y: u32,
+            a: *mut c_double,
+            lda: u32,
+        );
+        pub fn cblas_dsyr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            a: *mut c_double,
+            lda: u32,
+        );
+        pub fn cblas_dsyr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            y: *const c_double,
+            inc_y: u32,
+            a: *mut c_double,
+            lda: u32,
+        );
+        pub fn cblas_dspmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dgbmv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            kl: u32,
+            ku: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dsbmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dtbmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_double,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dtbsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_double,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dtpmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_double,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dtpsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_double,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dspr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            a: *mut c_double,
+        );
+        pub fn cblas_dspr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            y: *const c_double,
+            inc_y: u32,
+            a: *mut c_double,
+        );
     }
 }
 
@@ -119,25 +451,219 @@ pub mod cblas_c {
     pub use self::cblas_ctrmv as trmv;
     pub use self::cblas_ctrsv as trsv;
 
-    extern {
-        pub fn cblas_cgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_csymv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_chemv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ctrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ctrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_cgeru(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_cgerc(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_cher(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_void,   inc_x: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_cher2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_cgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_chbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ctbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ctbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_chpmv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ctpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ctpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_chpr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_void,   inc_x: u32, a: *mut c_void);
-        pub fn cblas_chpr2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void);
+    extern "C" {
+        pub fn cblas_cgemv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_csymv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_chemv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ctrmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            lda: u32,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ctrsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            lda: u32,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_cgeru(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_cgerc(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_cher(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_void,
+            inc_x: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_cher2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_cgbmv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            kl: u32,
+            ku: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_chbmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ctbmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ctbsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_chpmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ctpmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ctpsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_chpr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_void,
+            inc_x: u32,
+            a: *mut c_void,
+        );
+        pub fn cblas_chpr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+        );
     }
 }
 
@@ -164,24 +690,218 @@ pub mod cblas_z {
     pub use self::cblas_ztrmv as trmv;
     pub use self::cblas_ztrsv as trsv;
 
-    extern {
-        pub fn cblas_zgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zsymv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zhemv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ztrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ztrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zgeru(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_zgerc(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_zher(order: Order, sym: Symmetry, n: u32, alpha: c_double, x: *const c_void,   inc_x: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_zher2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_zgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zhbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ztbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ztbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zhpmv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ztpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ztpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zhpr(order: Order, sym: Symmetry, n: u32, alpha: c_double, x: *const c_void,   inc_x: u32, a: *mut c_void);
-        pub fn cblas_zhpr2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void);
+    extern "C" {
+        pub fn cblas_zgemv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_zsymv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_zhemv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ztrmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            lda: u32,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ztrsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            lda: u32,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_zgeru(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_zgerc(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_zher(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_void,
+            inc_x: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_zher2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_zgbmv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            kl: u32,
+            ku: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_zhbmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ztbmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ztbsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_zhpmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ztpmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ztpsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_zhpr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_void,
+            inc_x: u32,
+            a: *mut c_void,
+        );
+        pub fn cblas_zhpr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+        );
     }
 }

--- a/rust-blas/src/pointer.rs
+++ b/rust-blas/src/pointer.rs
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use libc::{c_double, c_float, c_int, c_long, c_void};
+use libc::{c_double, c_float, c_long, c_void};
 use num_complex::{Complex32, Complex64};
 
 pub trait CPtr<T> {
@@ -27,7 +27,7 @@ macro_rules! c_ptr_impl(
     );
 );
 
-c_ptr_impl!(i32, c_int);
+c_ptr_impl!(i32, u32);
 c_ptr_impl!(i64, c_long);
 c_ptr_impl!(f32, c_float);
 c_ptr_impl!(f64, c_double);

--- a/rust-blas/src/vector/ll.rs
+++ b/rust-blas/src/vector/ll.rs
@@ -22,21 +22,62 @@ pub mod cblas_s {
     pub use self::cblas_sscal as scal;
     pub use self::cblas_sswap as swap;
 
-    extern {
-        pub fn cblas_scopy(n: u32, x: *const c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
-        pub fn cblas_saxpy(n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
-        pub fn cblas_sscal(n: u32, alpha: c_float,       x: *mut c_float,  inc_x: u32);
-        pub fn cblas_sswap(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
-        pub fn cblas_sdsdot(n: u32, alpha: c_float, x: *const c_float, inc_x: u32, y: *const c_float, inc_y: u32) -> c_float;
-        pub fn cblas_sdot(n: u32, x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32) -> c_float;
-        pub fn cblas_sasum(n: u32, x: *const c_float,  inc_x: u32) -> c_float;
-        pub fn cblas_scasum(n: u32, x: *const c_void,   inc_x: u32) -> c_float;
-        pub fn cblas_snrm2(n: u32, x: *const c_float,  inc_x: u32) -> c_float;
-        pub fn cblas_scnrm2(n: u32, x: *const c_void,   inc_x: u32) -> c_float;
-        pub fn cblas_srot(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32, c: c_float,  s: c_float);
-        pub fn cblas_srotm(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32, p: *const c_float);
-        pub fn cblas_srotg(a: *mut c_float,  b: *mut c_float,  c: *mut c_float,  s: *mut c_float);
-        pub fn cblas_srotmg(d1: *mut c_float,  d2: *mut c_float,  b1: *mut c_float,  b2: c_float,  p: *mut c_float);
+    extern "C" {
+        pub fn cblas_scopy(n: u32, x: *const c_float, inc_x: u32, y: *mut c_float, inc_y: u32);
+        pub fn cblas_saxpy(
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_sscal(n: u32, alpha: c_float, x: *mut c_float, inc_x: u32);
+        pub fn cblas_sswap(n: u32, x: *mut c_float, inc_x: u32, y: *mut c_float, inc_y: u32);
+        pub fn cblas_sdsdot(
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+        ) -> c_float;
+        pub fn cblas_sdot(
+            n: u32,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+        ) -> c_float;
+        pub fn cblas_sasum(n: u32, x: *const c_float, inc_x: u32) -> c_float;
+        pub fn cblas_scasum(n: u32, x: *const c_void, inc_x: u32) -> c_float;
+        pub fn cblas_snrm2(n: u32, x: *const c_float, inc_x: u32) -> c_float;
+        pub fn cblas_scnrm2(n: u32, x: *const c_void, inc_x: u32) -> c_float;
+        pub fn cblas_srot(
+            n: u32,
+            x: *mut c_float,
+            inc_x: u32,
+            y: *mut c_float,
+            inc_y: u32,
+            c: c_float,
+            s: c_float,
+        );
+        pub fn cblas_srotm(
+            n: u32,
+            x: *mut c_float,
+            inc_x: u32,
+            y: *mut c_float,
+            inc_y: u32,
+            p: *const c_float,
+        );
+        pub fn cblas_srotg(a: *mut c_float, b: *mut c_float, c: *mut c_float, s: *mut c_float);
+        pub fn cblas_srotmg(
+            d1: *mut c_float,
+            d2: *mut c_float,
+            b1: *mut c_float,
+            b2: c_float,
+            p: *mut c_float,
+        );
     }
 }
 
@@ -58,19 +99,53 @@ pub mod cblas_d {
     pub use self::cblas_dzasum as zasum;
     pub use self::cblas_dznrm2 as znrm2;
 
-    extern {
+    extern "C" {
         pub fn cblas_dcopy(n: u32, x: *const c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
-        pub fn cblas_daxpy(n: u32, alpha: c_double,      x: *const c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
-        pub fn cblas_dscal (n: u32, alpha: c_double,      x: *mut c_double, inc_x: u32);
+        pub fn cblas_daxpy(
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dscal(n: u32, alpha: c_double, x: *mut c_double, inc_x: u32);
         pub fn cblas_dswap(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
-        pub fn cblas_dsdot(n: u32, x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32) -> c_double;
-        pub fn cblas_ddot (n: u32, x: *const c_double, inc_x: u32, y: *const c_double, inc_y: u32) -> c_double;
-        pub fn cblas_dasum (n: u32, x: *const c_double, inc_x: u32) -> c_double;
-        pub fn cblas_dzasum(n: u32, x: *const c_void,   inc_x: u32) -> c_double;
-        pub fn cblas_dnrm2 (n: u32, x: *const c_double, inc_x: u32) -> c_double;
-        pub fn cblas_dznrm2(n: u32, x: *const c_void,   inc_x: u32) -> c_double;
-        pub fn cblas_drot(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32, c: c_double, s: c_double);
-        pub fn cblas_drotm(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32, p: *const c_double);
+        pub fn cblas_dsdot(
+            n: u32,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+        ) -> c_double;
+        pub fn cblas_ddot(
+            n: u32,
+            x: *const c_double,
+            inc_x: u32,
+            y: *const c_double,
+            inc_y: u32,
+        ) -> c_double;
+        pub fn cblas_dasum(n: u32, x: *const c_double, inc_x: u32) -> c_double;
+        pub fn cblas_dzasum(n: u32, x: *const c_void, inc_x: u32) -> c_double;
+        pub fn cblas_dnrm2(n: u32, x: *const c_double, inc_x: u32) -> c_double;
+        pub fn cblas_dznrm2(n: u32, x: *const c_void, inc_x: u32) -> c_double;
+        pub fn cblas_drot(
+            n: u32,
+            x: *mut c_double,
+            inc_x: u32,
+            y: *mut c_double,
+            inc_y: u32,
+            c: c_double,
+            s: c_double,
+        );
+        pub fn cblas_drotm(
+            n: u32,
+            x: *mut c_double,
+            inc_x: u32,
+            y: *mut c_double,
+            inc_y: u32,
+            p: *const c_double,
+        );
         pub fn cblas_drotg(a: *mut c_double, b: *mut c_double, c: *mut c_double, s: *mut c_double);
         pub fn cblas_drotmg(
             d1: *mut c_double,
@@ -93,14 +168,35 @@ pub mod cblas_c {
     pub use self::cblas_csscal as sscal;
     pub use self::cblas_cswap as swap;
 
-    extern {
-        pub fn cblas_ccopy(n: u32, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_caxpy(n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_cscal (n: u32, alpha: *const c_void, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_csscal(n: u32, alpha: c_float,       x: *mut c_void,   inc_x: u32);
-        pub fn cblas_cswap(n: u32, x: *mut c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_cdotu_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotu: *mut c_void);
-        pub fn cblas_cdotc_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotc: *mut c_void);
+    extern "C" {
+        pub fn cblas_ccopy(n: u32, x: *const c_void, inc_x: u32, y: *mut c_void, inc_y: u32);
+        pub fn cblas_caxpy(
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_cscal(n: u32, alpha: *const c_void, x: *mut c_void, inc_x: u32);
+        pub fn cblas_csscal(n: u32, alpha: c_float, x: *mut c_void, inc_x: u32);
+        pub fn cblas_cswap(n: u32, x: *mut c_void, inc_x: u32, y: *mut c_void, inc_y: u32);
+        pub fn cblas_cdotu_sub(
+            n: u32,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            dotu: *mut c_void,
+        );
+        pub fn cblas_cdotc_sub(
+            n: u32,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            dotc: *mut c_void,
+        );
     }
 }
 
@@ -115,14 +211,35 @@ pub mod cblas_z {
     pub use self::cblas_zscal as scal;
     pub use self::cblas_zswap as swap;
 
-    extern {
-        pub fn cblas_zcopy(n: u32, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zaxpy(n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zscal (n: u32, alpha: *const c_void, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zdscal(n: u32, alpha: c_double,      x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zswap(n: u32, x: *mut c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zdotu_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotu: *mut c_void);
-        pub fn cblas_zdotc_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotc: *mut c_void);
+    extern "C" {
+        pub fn cblas_zcopy(n: u32, x: *const c_void, inc_x: u32, y: *mut c_void, inc_y: u32);
+        pub fn cblas_zaxpy(
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_zscal(n: u32, alpha: *const c_void, x: *mut c_void, inc_x: u32);
+        pub fn cblas_zdscal(n: u32, alpha: c_double, x: *mut c_void, inc_x: u32);
+        pub fn cblas_zswap(n: u32, x: *mut c_void, inc_x: u32, y: *mut c_void, inc_y: u32);
+        pub fn cblas_zdotu_sub(
+            n: u32,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            dotu: *mut c_void,
+        );
+        pub fn cblas_zdotc_sub(
+            n: u32,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            dotc: *mut c_void,
+        );
     }
 }
 
@@ -134,10 +251,10 @@ pub mod cblas_i {
     pub use self::cblas_isamax as samax;
     pub use self::cblas_izamax as zamax;
 
-    extern {
-        pub fn cblas_isamax(n: u32, x: *const c_float,  inc_x: u32) -> size_t;
+    extern "C" {
+        pub fn cblas_isamax(n: u32, x: *const c_float, inc_x: u32) -> size_t;
         pub fn cblas_idamax(n: u32, x: *const c_double, inc_x: u32) -> size_t;
-        pub fn cblas_icamax(n: u32, x: *const c_void,   inc_x: u32) -> size_t;
-        pub fn cblas_izamax(n: u32, x: *const c_void,   inc_x: u32) -> size_t;
+        pub fn cblas_icamax(n: u32, x: *const c_void, inc_x: u32) -> size_t;
+        pub fn cblas_izamax(n: u32, x: *const c_void, inc_x: u32) -> size_t;
     }
 }

--- a/rust-blas/src/vector/ll.rs
+++ b/rust-blas/src/vector/ll.rs
@@ -5,7 +5,7 @@
 //! Bindings for vector functions.
 
 pub mod cblas_s {
-    use libc::{c_float, c_int, c_void};
+    use libc::{c_float, c_void};
 
     pub use self::cblas_sasum as asum;
     pub use self::cblas_saxpy as axpy;
@@ -22,73 +22,26 @@ pub mod cblas_s {
     pub use self::cblas_sscal as scal;
     pub use self::cblas_sswap as swap;
 
-    extern "C" {
-        pub fn cblas_scopy(
-            n: c_int,
-            x: *const c_float,
-            inc_x: c_int,
-            y: *mut c_float,
-            inc_y: c_int,
-        );
-        pub fn cblas_saxpy(
-            n: c_int,
-            alpha: c_float,
-            x: *const c_float,
-            inc_x: c_int,
-            y: *mut c_float,
-            inc_y: c_int,
-        );
-        pub fn cblas_sscal(n: c_int, alpha: c_float, x: *mut c_float, inc_x: c_int);
-        pub fn cblas_sswap(n: c_int, x: *mut c_float, inc_x: c_int, y: *mut c_float, inc_y: c_int);
-        pub fn cblas_sdsdot(
-            n: c_int,
-            alpha: c_float,
-            x: *const c_float,
-            inc_x: c_int,
-            y: *const c_float,
-            inc_y: c_int,
-        ) -> c_float;
-        pub fn cblas_sdot(
-            n: c_int,
-            x: *const c_float,
-            inc_x: c_int,
-            y: *const c_float,
-            inc_y: c_int,
-        ) -> c_float;
-        pub fn cblas_sasum(n: c_int, x: *const c_float, inc_x: c_int) -> c_float;
-        pub fn cblas_scasum(n: c_int, x: *const c_void, inc_x: c_int) -> c_float;
-        pub fn cblas_snrm2(n: c_int, x: *const c_float, inc_x: c_int) -> c_float;
-        pub fn cblas_scnrm2(n: c_int, x: *const c_void, inc_x: c_int) -> c_float;
-        pub fn cblas_srot(
-            n: c_int,
-            x: *mut c_float,
-            inc_x: c_int,
-            y: *mut c_float,
-            inc_y: c_int,
-            c: c_float,
-            s: c_float,
-        );
-        pub fn cblas_srotm(
-            n: c_int,
-            x: *mut c_float,
-            inc_x: c_int,
-            y: *mut c_float,
-            inc_y: c_int,
-            p: *const c_float,
-        );
-        pub fn cblas_srotg(a: *mut c_float, b: *mut c_float, c: *mut c_float, s: *mut c_float);
-        pub fn cblas_srotmg(
-            d1: *mut c_float,
-            d2: *mut c_float,
-            b1: *mut c_float,
-            b2: c_float,
-            p: *mut c_float,
-        );
+    extern {
+        pub fn cblas_scopy(n: u32, x: *const c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
+        pub fn cblas_saxpy(n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
+        pub fn cblas_sscal(n: u32, alpha: c_float,       x: *mut c_float,  inc_x: u32);
+        pub fn cblas_sswap(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
+        pub fn cblas_sdsdot(n: u32, alpha: c_float, x: *const c_float, inc_x: u32, y: *const c_float, inc_y: u32) -> c_float;
+        pub fn cblas_sdot(n: u32, x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32) -> c_float;
+        pub fn cblas_sasum(n: u32, x: *const c_float,  inc_x: u32) -> c_float;
+        pub fn cblas_scasum(n: u32, x: *const c_void,   inc_x: u32) -> c_float;
+        pub fn cblas_snrm2(n: u32, x: *const c_float,  inc_x: u32) -> c_float;
+        pub fn cblas_scnrm2(n: u32, x: *const c_void,   inc_x: u32) -> c_float;
+        pub fn cblas_srot(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32, c: c_float,  s: c_float);
+        pub fn cblas_srotm(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32, p: *const c_float);
+        pub fn cblas_srotg(a: *mut c_float,  b: *mut c_float,  c: *mut c_float,  s: *mut c_float);
+        pub fn cblas_srotmg(d1: *mut c_float,  d2: *mut c_float,  b1: *mut c_float,  b2: c_float,  p: *mut c_float);
     }
 }
 
 pub mod cblas_d {
-    use libc::{c_double, c_float, c_int, c_void};
+    use libc::{c_double, c_float, c_void};
 
     pub use self::cblas_dasum as asum;
     pub use self::cblas_daxpy as axpy;
@@ -105,65 +58,19 @@ pub mod cblas_d {
     pub use self::cblas_dzasum as zasum;
     pub use self::cblas_dznrm2 as znrm2;
 
-    extern "C" {
-        pub fn cblas_dcopy(
-            n: c_int,
-            x: *const c_double,
-            inc_x: c_int,
-            y: *mut c_double,
-            inc_y: c_int,
-        );
-        pub fn cblas_daxpy(
-            n: c_int,
-            alpha: c_double,
-            x: *const c_double,
-            inc_x: c_int,
-            y: *mut c_double,
-            inc_y: c_int,
-        );
-        pub fn cblas_dscal(n: c_int, alpha: c_double, x: *mut c_double, inc_x: c_int);
-        pub fn cblas_dswap(
-            n: c_int,
-            x: *mut c_double,
-            inc_x: c_int,
-            y: *mut c_double,
-            inc_y: c_int,
-        );
-        pub fn cblas_dsdot(
-            n: c_int,
-            x: *const c_float,
-            inc_x: c_int,
-            y: *const c_float,
-            inc_y: c_int,
-        ) -> c_double;
-        pub fn cblas_ddot(
-            n: c_int,
-            x: *const c_double,
-            inc_x: c_int,
-            y: *const c_double,
-            inc_y: c_int,
-        ) -> c_double;
-        pub fn cblas_dasum(n: c_int, x: *const c_double, inc_x: c_int) -> c_double;
-        pub fn cblas_dzasum(n: c_int, x: *const c_void, inc_x: c_int) -> c_double;
-        pub fn cblas_dnrm2(n: c_int, x: *const c_double, inc_x: c_int) -> c_double;
-        pub fn cblas_dznrm2(n: c_int, x: *const c_void, inc_x: c_int) -> c_double;
-        pub fn cblas_drot(
-            n: c_int,
-            x: *mut c_double,
-            inc_x: c_int,
-            y: *mut c_double,
-            inc_y: c_int,
-            c: c_double,
-            s: c_double,
-        );
-        pub fn cblas_drotm(
-            n: c_int,
-            x: *mut c_double,
-            inc_x: c_int,
-            y: *mut c_double,
-            inc_y: c_int,
-            p: *const c_double,
-        );
+    extern {
+        pub fn cblas_dcopy(n: u32, x: *const c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
+        pub fn cblas_daxpy(n: u32, alpha: c_double,      x: *const c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
+        pub fn cblas_dscal (n: u32, alpha: c_double,      x: *mut c_double, inc_x: u32);
+        pub fn cblas_dswap(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
+        pub fn cblas_dsdot(n: u32, x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32) -> c_double;
+        pub fn cblas_ddot (n: u32, x: *const c_double, inc_x: u32, y: *const c_double, inc_y: u32) -> c_double;
+        pub fn cblas_dasum (n: u32, x: *const c_double, inc_x: u32) -> c_double;
+        pub fn cblas_dzasum(n: u32, x: *const c_void,   inc_x: u32) -> c_double;
+        pub fn cblas_dnrm2 (n: u32, x: *const c_double, inc_x: u32) -> c_double;
+        pub fn cblas_dznrm2(n: u32, x: *const c_void,   inc_x: u32) -> c_double;
+        pub fn cblas_drot(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32, c: c_double, s: c_double);
+        pub fn cblas_drotm(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32, p: *const c_double);
         pub fn cblas_drotg(a: *mut c_double, b: *mut c_double, c: *mut c_double, s: *mut c_double);
         pub fn cblas_drotmg(
             d1: *mut c_double,
@@ -176,7 +83,7 @@ pub mod cblas_d {
 }
 
 pub mod cblas_c {
-    use libc::{c_float, c_int, c_void};
+    use libc::{c_float, c_void};
 
     pub use self::cblas_caxpy as axpy;
     pub use self::cblas_ccopy as copy;
@@ -186,40 +93,19 @@ pub mod cblas_c {
     pub use self::cblas_csscal as sscal;
     pub use self::cblas_cswap as swap;
 
-    extern "C" {
-        pub fn cblas_ccopy(n: c_int, x: *const c_void, inc_x: c_int, y: *mut c_void, inc_y: c_int);
-        pub fn cblas_caxpy(
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_cscal(n: c_int, alpha: *const c_void, x: *mut c_void, inc_x: c_int);
-        pub fn cblas_csscal(n: c_int, alpha: c_float, x: *mut c_void, inc_x: c_int);
-        pub fn cblas_cswap(n: c_int, x: *mut c_void, inc_x: c_int, y: *mut c_void, inc_y: c_int);
-        pub fn cblas_cdotu_sub(
-            n: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            dotu: *mut c_void,
-        );
-        pub fn cblas_cdotc_sub(
-            n: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            dotc: *mut c_void,
-        );
+    extern {
+        pub fn cblas_ccopy(n: u32, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_caxpy(n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_cscal (n: u32, alpha: *const c_void, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_csscal(n: u32, alpha: c_float,       x: *mut c_void,   inc_x: u32);
+        pub fn cblas_cswap(n: u32, x: *mut c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_cdotu_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotu: *mut c_void);
+        pub fn cblas_cdotc_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotc: *mut c_void);
     }
 }
 
 pub mod cblas_z {
-    use libc::{c_double, c_int, c_void};
+    use libc::{c_double, c_void};
 
     pub use self::cblas_zaxpy as axpy;
     pub use self::cblas_zcopy as copy;
@@ -229,50 +115,29 @@ pub mod cblas_z {
     pub use self::cblas_zscal as scal;
     pub use self::cblas_zswap as swap;
 
-    extern "C" {
-        pub fn cblas_zcopy(n: c_int, x: *const c_void, inc_x: c_int, y: *mut c_void, inc_y: c_int);
-        pub fn cblas_zaxpy(
-            n: c_int,
-            alpha: *const c_void,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *mut c_void,
-            inc_y: c_int,
-        );
-        pub fn cblas_zscal(n: c_int, alpha: *const c_void, x: *mut c_void, inc_x: c_int);
-        pub fn cblas_zdscal(n: c_int, alpha: c_double, x: *mut c_void, inc_x: c_int);
-        pub fn cblas_zswap(n: c_int, x: *mut c_void, inc_x: c_int, y: *mut c_void, inc_y: c_int);
-        pub fn cblas_zdotu_sub(
-            n: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            dotu: *mut c_void,
-        );
-        pub fn cblas_zdotc_sub(
-            n: c_int,
-            x: *const c_void,
-            inc_x: c_int,
-            y: *const c_void,
-            inc_y: c_int,
-            dotc: *mut c_void,
-        );
+    extern {
+        pub fn cblas_zcopy(n: u32, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zaxpy(n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zscal (n: u32, alpha: *const c_void, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zdscal(n: u32, alpha: c_double,      x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zswap(n: u32, x: *mut c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zdotu_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotu: *mut c_void);
+        pub fn cblas_zdotc_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotc: *mut c_void);
     }
 }
 
 pub mod cblas_i {
-    use libc::{c_double, c_float, c_int, c_void, size_t};
+    use libc::{c_double, c_float, c_void, size_t};
 
     pub use self::cblas_icamax as camax;
     pub use self::cblas_idamax as damax;
     pub use self::cblas_isamax as samax;
     pub use self::cblas_izamax as zamax;
 
-    extern "C" {
-        pub fn cblas_isamax(n: c_int, x: *const c_float, inc_x: c_int) -> size_t;
-        pub fn cblas_idamax(n: c_int, x: *const c_double, inc_x: c_int) -> size_t;
-        pub fn cblas_icamax(n: c_int, x: *const c_void, inc_x: c_int) -> size_t;
-        pub fn cblas_izamax(n: c_int, x: *const c_void, inc_x: c_int) -> size_t;
+    extern {
+        pub fn cblas_isamax(n: u32, x: *const c_float,  inc_x: u32) -> size_t;
+        pub fn cblas_idamax(n: u32, x: *const c_double, inc_x: u32) -> size_t;
+        pub fn cblas_icamax(n: u32, x: *const c_void,   inc_x: u32) -> size_t;
+        pub fn cblas_izamax(n: u32, x: *const c_void,   inc_x: u32) -> size_t;
     }
 }

--- a/rust-blas/src/vector/mod.rs
+++ b/rust-blas/src/vector/mod.rs
@@ -4,7 +4,6 @@
 
 //! Vector operations.
 use crate::vector::ops::{Asum, Axpy, Copy, Dot, Iamax, Nrm2, Scal};
-use libc::c_int;
 use num::traits::NumCast;
 use num_complex::{Complex32, Complex64};
 
@@ -15,11 +14,11 @@ pub mod ops;
 pub trait Vector<T> {
     /// The stride within the vector. For example, if `inc` returns 7, every
     /// 7th element is used. Defaults to 1.
-    fn inc(&self) -> c_int {
+    fn inc(&self) -> u32 {
         1
     }
     /// The number of elements in the vector.
-    fn len(&self) -> c_int;
+    fn len(&self) -> u32;
     /// An unsafe pointer to a contiguous block of memory.
     fn as_ptr(&self) -> *const T;
     /// An unsafe mutable pointer to a contiguous block of memory.
@@ -82,8 +81,8 @@ where
 
 impl<T> Vector<T> for Vec<T> {
     #[inline]
-    fn len(&self) -> c_int {
-        let l: Option<c_int> = NumCast::from(Vec::len(self));
+    fn len(&self) -> u32 {
+        let l: Option<u32> = NumCast::from(Vec::len(self));
         match l {
             Some(l) => l,
             None => panic!(),
@@ -103,8 +102,8 @@ impl<T> Vector<T> for Vec<T> {
 
 impl<T> Vector<T> for [T] {
     #[inline]
-    fn len(&self) -> c_int {
-        let l: Option<c_int> = NumCast::from(<[T]>::len(self));
+    fn len(&self) -> u32 {
+        let l: Option<u32> = NumCast::from(<[T]>::len(self));
         match l {
             Some(l) => l,
             None => panic!(),


### PR DESCRIPTION
Got rid of usage of c_int throughout the `rust-blas` project, replacing what was
essentially an alias for i32 with u32.