### PR TITLE
Adding GBMV trait to Native backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,7 @@ name = "juice-examples"
 version = "0.1.1"
 dependencies = [
  "coaster",
+ "coaster-nn",
  "csv",
  "docopt",
  "env_logger 0.7.1",

--- a/coaster-blas/benches/rblas_overhead.rs
+++ b/coaster-blas/benches/rblas_overhead.rs
@@ -1,17 +1,17 @@
 #![feature(test)]
 
-extern crate test;
 extern crate coaster as co;
 extern crate coaster_blas as co_blas;
-extern crate rust_blas as rblas;
 extern crate rand;
+extern crate rust_blas as rblas;
+extern crate test;
 
-use test::Bencher;
 use crate::co::prelude::*;
 use crate::co_blas::plugin::*;
+use test::Bencher;
 
-use rand::{thread_rng, Rng};
 use rand::distributions::Standard;
+use rand::{thread_rng, Rng};
 
 fn backend() -> Backend<Native> {
     Backend::<Native>::default().unwrap()
@@ -37,43 +37,67 @@ fn bench_dot_coaster(b: &mut Bencher, n: usize) {
     let shared_a = &mut SharedTensor::<f32>::new(&[n]);
     let shared_b = &mut SharedTensor::<f32>::new(&[n]);
     let shared_res = &mut SharedTensor::<f32>::new(&[1]);
-    shared_a.write_only(backend.device()).unwrap()
-        .as_mut_slice().clone_from_slice(slice_a.as_slice());
-    shared_b.write_only(backend.device()).unwrap()
-        .as_mut_slice().clone_from_slice(slice_b.as_slice());
+    shared_a
+        .write_only(backend.device())
+        .unwrap()
+        .as_mut_slice()
+        .clone_from_slice(slice_a.as_slice());
+    shared_b
+        .write_only(backend.device())
+        .unwrap()
+        .as_mut_slice()
+        .clone_from_slice(slice_b.as_slice());
     let _ = backend.dot(shared_a, shared_b, shared_res);
 
     b.iter(|| backend.dot(shared_a, shared_b, shared_res).unwrap());
 }
 
-
+#[bench]
+fn bench_dot_100_rblas(b: &mut Bencher) {
+    bench_dot_rblas(b, 100);
+}
 
 #[bench]
-fn bench_dot_100_rblas(b: &mut Bencher) { bench_dot_rblas(b, 100); }
+fn bench_dot_100_coaster(b: &mut Bencher) {
+    bench_dot_coaster(b, 100);
+}
 
 #[bench]
-fn bench_dot_100_coaster(b: &mut Bencher) { bench_dot_coaster(b, 100); }
+fn bench_dot_1000_rblas(b: &mut Bencher) {
+    bench_dot_rblas(b, 1000);
+}
 
 #[bench]
-fn bench_dot_1000_rblas(b: &mut Bencher) { bench_dot_rblas(b, 1000); }
+fn bench_dot_1000_coaster(b: &mut Bencher) {
+    bench_dot_coaster(b, 1000);
+}
 
 #[bench]
-fn bench_dot_1000_coaster(b: &mut Bencher) { bench_dot_coaster(b, 1000); }
+fn bench_dot_2000_rblas(b: &mut Bencher) {
+    bench_dot_rblas(b, 2000);
+}
 
 #[bench]
-fn bench_dot_2000_rblas(b: &mut Bencher) { bench_dot_rblas(b, 2000); }
+fn bench_dot_2000_coaster(b: &mut Bencher) {
+    bench_dot_coaster(b, 2000);
+}
 
 #[bench]
-fn bench_dot_2000_coaster(b: &mut Bencher) { bench_dot_coaster(b, 2000); }
+fn bench_dot_10000_rblas(b: &mut Bencher) {
+    bench_dot_rblas(b, 10000);
+}
 
 #[bench]
-fn bench_dot_10000_rblas(b: &mut Bencher) { bench_dot_rblas(b, 10000); }
+fn bench_dot_10000_coaster(b: &mut Bencher) {
+    bench_dot_coaster(b, 10000);
+}
 
 #[bench]
-fn bench_dot_10000_coaster(b: &mut Bencher) { bench_dot_coaster(b, 10000); }
+fn bench_dot_20000_rblas(b: &mut Bencher) {
+    bench_dot_rblas(b, 20000);
+}
 
 #[bench]
-fn bench_dot_20000_rblas(b: &mut Bencher) { bench_dot_rblas(b, 20000); }
-
-#[bench]
-fn bench_dot_20000_coaster(b: &mut Bencher) { bench_dot_coaster(b, 20000); }
+fn bench_dot_20000_coaster(b: &mut Bencher) {
+    bench_dot_coaster(b, 20000);
+}

--- a/coaster-blas/src/frameworks/cuda/helper.rs
+++ b/coaster-blas/src/frameworks/cuda/helper.rs
@@ -165,6 +165,26 @@ macro_rules! iblas_swap_for_cuda {
     );
 }
 
+/// gbmv for cuda
+#[macro_export]
+macro_rules! iblas_gbmv_for_cuda {
+    ($t:ident) => {
+        fn gbmv(
+            &self,
+            alpha: &SharedTensor<$t>,
+            at: Transpose,
+            a: &SharedTensor<$t>,
+            kl: &SharedTensor<u32>,
+            ku: &SharedTensor<u32>,
+            x: &SharedTensor<$t>,
+            beta: &SharedTensor<$t>,
+            c: &mut SharedTensor<$t>,
+        ) -> Result<(), ::coaster::error::Error> {
+            unimplemented!();
+        }
+    }
+}
+
 /// gemm for cuda
 #[macro_export]
 macro_rules! iblas_gemm_for_cuda {

--- a/coaster-blas/src/frameworks/cuda/helper.rs
+++ b/coaster-blas/src/frameworks/cuda/helper.rs
@@ -2,32 +2,32 @@
 /// to return typed memory. For now they remove a lot of visual clutter and
 /// lessen probability of stupid mistakes.
 macro_rules! read {
-    ($x:ident, $slf:ident) => (
+    ($x:ident, $slf:ident) => {
         $x.read($slf.device())?
-    )
+    };
 }
 
 /// acquire a tensor as read write
 macro_rules! read_write {
-    ($x:ident, $slf:ident) => (
+    ($x:ident, $slf:ident) => {
         $x.read_write($slf.device())?
-    )
+    };
 }
 
 /// acquire a tensor as write only
 macro_rules! write_only {
-    ($x:ident, $slf:ident) => (
+    ($x:ident, $slf:ident) => {
         $x.write_only($slf.device())?
-    )
+    };
 }
 
 /// trans! cannot be inlined into macros above, because `$mem` would become
 /// intermidiate variable and `*mut $t` will outlive it.
 macro_rules! trans {
-    ($mem:ident, $t:ident) => (
+    ($mem:ident, $t:ident) => {
         *$mem.id_c() as *mut f32
         //::std::mem::transmute::<u64, *mut $t>(*$mem.id_c()) }
-    )
+    };
 }
 
 /// execute something and map the error as a plugin error
@@ -39,130 +39,162 @@ macro_rules! exec {
     })
 }
 
-
 /// asum with cuda
 #[macro_export]
 macro_rules! iblas_asum_for_cuda {
-    ($t:ident) => (
-        fn asum(&self, x: &SharedTensor<$t>, result: &mut SharedTensor<$t>)
-                -> Result<(), ::coaster::error::Error> {
+    ($t:ident) => {
+        fn asum(
+            &self,
+            x: &SharedTensor<$t>,
+            result: &mut SharedTensor<$t>,
+        ) -> Result<(), ::coaster::error::Error> {
             let n = x.desc().size() as i32;
             let x_mem = read!(x, self);
             let r_mem = write_only!(result, self);
-            exec!(asum, CONTEXT.asum(
-                trans!(x_mem, $t),
-                trans!(r_mem, $t),
-                n, None))
+            exec!(
+                asum,
+                CONTEXT.asum(trans!(x_mem, $t), trans!(r_mem, $t), n, None)
+            )
         }
-    );
+    };
 }
 
 /// axpy with cuda
 #[macro_export]
 macro_rules! iblas_axpy_for_cuda {
-    ($t:ident) => (
-        fn axpy(&self, a: &SharedTensor<$t>, x: &SharedTensor<$t>,
-                y: &mut SharedTensor<$t>)
-                -> Result<(), ::coaster::error::Error> {
+    ($t:ident) => {
+        fn axpy(
+            &self,
+            a: &SharedTensor<$t>,
+            x: &SharedTensor<$t>,
+            y: &mut SharedTensor<$t>,
+        ) -> Result<(), ::coaster::error::Error> {
             let n = x.desc().size() as i32;
             let a_mem = read!(a, self);
             let x_mem = read!(x, self);
             let y_mem = read_write!(y, self);
-            exec!(axpy, CONTEXT.axpy(
-                trans!(a_mem, $t),
-                trans!(x_mem, $t),
-                trans!(y_mem, $t),
-                n, None, None))
+            exec!(
+                axpy,
+                CONTEXT.axpy(
+                    trans!(a_mem, $t),
+                    trans!(x_mem, $t),
+                    trans!(y_mem, $t),
+                    n,
+                    None,
+                    None
+                )
+            )
         }
-    );
+    };
 }
 
 /// copy for cuda
 #[macro_export]
 macro_rules! iblas_copy_for_cuda {
-    ($t:ident) => (
-        fn copy(&self, x: &SharedTensor<$t>, y: &mut SharedTensor<$t>)
-                -> Result<(), ::coaster::error::Error> {
+    ($t:ident) => {
+        fn copy(
+            &self,
+            x: &SharedTensor<$t>,
+            y: &mut SharedTensor<$t>,
+        ) -> Result<(), ::coaster::error::Error> {
             let n = x.desc().size() as i32;
             let x_mem = read!(x, self);
             let y_mem = write_only!(y, self);
-            exec!(copy, CONTEXT.copy(
-                trans!(x_mem, $t),
-                trans!(y_mem, $t),
-                n, None, None))
+            exec!(
+                copy,
+                CONTEXT.copy(trans!(x_mem, $t), trans!(y_mem, $t), n, None, None)
+            )
         }
-    );
+    };
 }
 
 /// dot product for cuda
 #[macro_export]
 macro_rules! iblas_dot_for_cuda {
-    ($t:ident) => (
-        fn dot(&self, x: &SharedTensor<$t>, y: &SharedTensor<$t>,
-               result: &mut SharedTensor<$t>)
-               -> Result<(), ::coaster::error::Error> {
+    ($t:ident) => {
+        fn dot(
+            &self,
+            x: &SharedTensor<$t>,
+            y: &SharedTensor<$t>,
+            result: &mut SharedTensor<$t>,
+        ) -> Result<(), ::coaster::error::Error> {
             let n = x.desc().size() as i32;
             let x_mem = read!(x, self);
             let y_mem = read!(y, self);
             let r_mem = write_only!(result, self);
-            exec!(dot, CONTEXT.dot(
-                trans!(x_mem, $t),
-                trans!(y_mem, $t),
-                trans!(r_mem, $t),
-                n, None, None))
+            exec!(
+                dot,
+                CONTEXT.dot(
+                    trans!(x_mem, $t),
+                    trans!(y_mem, $t),
+                    trans!(r_mem, $t),
+                    n,
+                    None,
+                    None
+                )
+            )
         }
-    );
+    };
 }
 
 /// nrm2 for cuda
 #[macro_export]
 macro_rules! iblas_nrm2_for_cuda {
-    ($t:ident) => (
-        fn nrm2(&self, x: &SharedTensor<$t>, result: &mut SharedTensor<$t>)
-                -> Result<(), ::coaster::error::Error> {
+    ($t:ident) => {
+        fn nrm2(
+            &self,
+            x: &SharedTensor<$t>,
+            result: &mut SharedTensor<$t>,
+        ) -> Result<(), ::coaster::error::Error> {
             let n = x.desc().size() as i32;
             let x_mem = read!(x, self);
             let r_mem = write_only!(result, self);
-            exec!(nrm2, CONTEXT.nrm2(
-                trans!(x_mem, $t),
-                trans!(r_mem, $t),
-                n, None))
+            exec!(
+                nrm2,
+                CONTEXT.nrm2(trans!(x_mem, $t), trans!(r_mem, $t), n, None)
+            )
         }
-    );
+    };
 }
 
 /// scalar mul for cuda
 #[macro_export]
 macro_rules! iblas_scal_for_cuda {
-    ($t:ident) => (
-        fn scal(&self, a: &SharedTensor<$t>, x: &mut SharedTensor<$t>)
-                -> Result<(), ::coaster::error::Error> {
+    ($t:ident) => {
+        fn scal(
+            &self,
+            a: &SharedTensor<$t>,
+            x: &mut SharedTensor<$t>,
+        ) -> Result<(), ::coaster::error::Error> {
             let n = x.desc().size() as i32;
             let a_mem = read!(a, self);
             let x_mem = read_write!(x, self);
-            exec!(scal, CONTEXT.scal(
-                trans!(a_mem, $t),
-                trans!(x_mem, $t),
-                n, None))
+            exec!(
+                scal,
+                CONTEXT.scal(trans!(a_mem, $t), trans!(x_mem, $t), n, None)
+            )
         }
-    );
+    };
 }
 
 /// swap matrices for cuda
 #[macro_export]
 macro_rules! iblas_swap_for_cuda {
-    ($t:ident) => (
-        fn swap(&self, x: &mut SharedTensor<$t>, y: &mut SharedTensor<$t>)
-                -> Result<(), ::coaster::error::Error> {
+    ($t:ident) => {
+        fn swap(
+            &self,
+            x: &mut SharedTensor<$t>,
+            y: &mut SharedTensor<$t>,
+        ) -> Result<(), ::coaster::error::Error> {
             let n = x.desc().size() as i32;
             let x_mem = read_write!(x, self);
             let y_mem = read_write!(y, self);
-            exec!(swap, CONTEXT.swap(
-                trans!(x_mem, $t),
-                trans!(y_mem, $t),
-                n, None, None))
+            exec!(
+                swap,
+                CONTEXT.swap(trans!(x_mem, $t), trans!(y_mem, $t), n, None, None)
+            )
         }
-    );
+    };
 }
 
 /// gbmv for cuda
@@ -171,32 +203,33 @@ macro_rules! iblas_gbmv_for_cuda {
     ($t:ident) => {
         fn gbmv(
             &self,
-            alpha: &SharedTensor<$t>,
-            at: Transpose,
-            a: &SharedTensor<$t>,
-            kl: &SharedTensor<u32>,
-            ku: &SharedTensor<u32>,
-            x: &SharedTensor<$t>,
-            beta: &SharedTensor<$t>,
-            c: &mut SharedTensor<$t>,
+            _alpha: &SharedTensor<$t>,
+            _at: Transpose,
+            _a: &SharedTensor<$t>,
+            _kl: &SharedTensor<u32>,
+            _ku: &SharedTensor<u32>,
+            _x: &SharedTensor<$t>,
+            _beta: &SharedTensor<$t>,
+            _c: &mut SharedTensor<$t>,
         ) -> Result<(), ::coaster::error::Error> {
             unimplemented!();
         }
-    }
+    };
 }
 
 /// gemm for cuda
 #[macro_export]
 macro_rules! iblas_gemm_for_cuda {
-    ($t:ident) => (
-        fn gemm(&self,
-                alpha: &SharedTensor<$t>,
-                at: Transpose,
-                a: &SharedTensor<$t>,
-                bt: Transpose,
-                b: &SharedTensor<$t>,
-                beta: &SharedTensor<$t>,
-                c: &mut SharedTensor<$t>
+    ($t:ident) => {
+        fn gemm(
+            &self,
+            alpha: &SharedTensor<$t>,
+            at: Transpose,
+            a: &SharedTensor<$t>,
+            bt: Transpose,
+            b: &SharedTensor<$t>,
+            beta: &SharedTensor<$t>,
+            c: &mut SharedTensor<$t>,
         ) -> Result<(), ::coaster::error::Error> {
             let c_desc = c.desc().clone();
             let alpha_mem = read!(alpha, self);
@@ -212,27 +245,33 @@ macro_rules! iblas_gemm_for_cuda {
             let c_1 = c_desc.iter().skip(1).fold(1, |prod, i| prod * i) as i32;
             let n = match bt {
                 Transpose::NoTrans => b_1,
-                _ => b_0
+                _ => b_0,
             };
             let (m, k) = match at {
                 Transpose::NoTrans => (a_0, a_1),
-                _ => (a_1, a_0)
+                _ => (a_1, a_0),
             };
             let lda = a_1;
             let ldb = b_1;
             let ldc = c_1;
-            exec!(gemm, CONTEXT.gemm(
-                ::cublas::api::Operation::from(bt),
-                ::cublas::api::Operation::from(at),
-                n, m, k,
-                trans!(alpha_mem, $t),
-                trans!(b_mem, $t), // matrix a and b are switched to make it work with row-major memory layout.
-                ldb,
-                trans!(a_mem, $t),
-                lda,
-                trans!(beta_mem, $t),
-                trans!(c_mem, $t),
-                ldc))
+            exec!(
+                gemm,
+                CONTEXT.gemm(
+                    ::cublas::api::Operation::from(bt),
+                    ::cublas::api::Operation::from(at),
+                    n,
+                    m,
+                    k,
+                    trans!(alpha_mem, $t),
+                    trans!(b_mem, $t), // matrix a and b are switched to make it work with row-major memory layout.
+                    ldb,
+                    trans!(a_mem, $t),
+                    lda,
+                    trans!(beta_mem, $t),
+                    trans!(c_mem, $t),
+                    ldc
+                )
+            )
         }
-    );
+    };
 }

--- a/coaster-blas/src/frameworks/cuda/mod.rs
+++ b/coaster-blas/src/frameworks/cuda/mod.rs
@@ -1,12 +1,12 @@
 //! Provides BLAS for a CUDA backend.
 #![allow(missing_docs)]
-use coaster::backend::Backend;
-use coaster::tensor::{SharedTensor, ITensorDesc};
-use coaster::plugin::Error as PluginError;
-use coaster::frameworks::cuda::Cuda;
 use crate::cublas;
 use crate::plugin::*;
 use crate::transpose::Transpose;
+use coaster::backend::Backend;
+use coaster::frameworks::cuda::Cuda;
+use coaster::plugin::Error as PluginError;
+use coaster::tensor::{ITensorDesc, SharedTensor};
 
 #[macro_use]
 pub mod helper;
@@ -14,7 +14,9 @@ pub mod helper;
 lazy_static! {
     static ref CONTEXT: cublas::Context = {
         let mut context = cublas::Context::new().unwrap();
-        context.set_pointer_mode(cublas::api::PointerMode::Device).unwrap();
+        context
+            .set_pointer_mode(cublas::api::PointerMode::Device)
+            .unwrap();
         context
     };
 }

--- a/coaster-blas/src/frameworks/cuda/mod.rs
+++ b/coaster-blas/src/frameworks/cuda/mod.rs
@@ -47,6 +47,10 @@ impl Swap<f32> for Backend<Cuda> {
     iblas_swap_for_cuda!(f32);
 }
 
+impl Gbmv<f32> for Backend<Cuda> {
+    iblas_gbmv_for_cuda!(f32);
+}
+
 impl Gemm<f32> for Backend<Cuda> {
     iblas_gemm_for_cuda!(f32);
 }

--- a/coaster-blas/src/frameworks/mod.rs
+++ b/coaster-blas/src/frameworks/mod.rs
@@ -1,8 +1,8 @@
 //! Provides the specific Framework implementations for the Library Operations.
 
-#[cfg(feature = "native")]
-pub mod native;
 #[cfg(feature = "cuda")]
 pub mod cuda;
+#[cfg(feature = "native")]
+pub mod native;
 #[cfg(feature = "opencl")]
 pub mod opencl;

--- a/coaster-blas/src/frameworks/native.rs
+++ b/coaster-blas/src/frameworks/native.rs
@@ -144,6 +144,8 @@ macro_rules! iblas_gbmv_for_native {
                 &read!(beta, $t, self)[0],
                 c_slice,
             );
+
+            Ok(())
         }
     }
 }

--- a/coaster-blas/src/frameworks/native.rs
+++ b/coaster-blas/src/frameworks/native.rs
@@ -167,7 +167,7 @@ macro_rules! iblas_gemm_for_native {
 
             let a_slice = read!(a, $t, self);
             let b_slice = read!(b, $t, self);
-            let c_slice = read_write!(c, $t, self);
+            let c_slice = write_only!(c, $t, self);
 
             let a_matrix = as_matrix(a_slice, a.desc().dims());
             let b_matrix = as_matrix(b_slice, b.desc().dims());

--- a/coaster-blas/src/frameworks/native.rs
+++ b/coaster-blas/src/frameworks/native.rs
@@ -120,8 +120,8 @@ macro_rules! iblas_gbmv_for_native {
             alpha: &SharedTensor<$t>,
             at: Transpose,
             a: &SharedTensor<$t>,
-            kl: &SharedTensor<$t>,
-            ku: &SharedTensor<$t>,
+            kl: &SharedTensor<u32>,
+            ku: &SharedTensor<u32>,
             x: &SharedTensor<$t>,
             beta: &SharedTensor<$t>,
             c: &mut SharedTensor<$t>) -> Result<(), ::coaster::error::Error> {
@@ -133,21 +133,17 @@ macro_rules! iblas_gbmv_for_native {
             let kl: u32 = read!(kl, u32, self)[0];
             let ku: u32 = read!(ku, u32, self)[0]; 
 
-            unsafe {
-                let a_matrix = as_matrix(a_slice, a.desc().dims());
-                let a_matrix = BandMat::from_matrix(a_matrix, kl, ku);
+            let a_matrix = as_matrix(a_slice, a.desc().dims());
+            let a_matrix = BandMat::from_matrix(a_matrix, kl, ku);
 
-                rblas::Gbmv::gbmv(
-                    at.to_rblas(),
-                    &read!(alpha, $t, self)[0],
-                    &a_matrix,
-                    x_slice,
-                    &read!(beta, $t, self)[0],
-                    c_slice
-                );
-
-                Ok(())
-            }
+            rblas::Gbmv::gbmv(
+                at.to_rblas(),
+                &read!(alpha, $t, self)[0],
+                &a_matrix,
+                x_slice,
+                &read!(beta, $t, self)[0],
+                c_slice,
+            );
         }
     }
 }

--- a/coaster-blas/src/lib.rs
+++ b/coaster-blas/src/lib.rs
@@ -43,22 +43,27 @@
 #![cfg_attr(lint, feature(plugin))]
 #![cfg_attr(lint, plugin(clippy))]
 #![allow(dead_code)]
-#![deny(missing_docs,
-        missing_debug_implementations, missing_copy_implementations,
-        trivial_casts, trivial_numeric_casts,
-        unused_import_braces, unused_qualifications)]
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_import_braces,
+    unused_qualifications
+)]
 
 #[macro_use]
 extern crate lazy_static;
 
 extern crate coaster;
-#[cfg(feature = "native")]
-extern crate rust_blas as rblas;
 #[cfg(feature = "cuda")]
 extern crate rcublas as cublas;
+#[cfg(feature = "native")]
+extern crate rust_blas as rblas;
 
-pub mod plugin;
 pub mod binary;
-pub mod operation;
-pub mod transpose;
 pub mod frameworks;
+pub mod operation;
+pub mod plugin;
+pub mod transpose;

--- a/coaster-blas/src/operation.rs
+++ b/coaster-blas/src/operation.rs
@@ -1,8 +1,8 @@
 //! Provides the IOperationX operation traits for Coaster's Framework implementation.
 
-use coaster::tensor::SharedTensor;
-use coaster::plugin::Error;
 use crate::transpose::Transpose;
+use coaster::plugin::Error;
+use coaster::tensor::SharedTensor;
 
 /// Describes a Asum Operation.
 pub trait IOperationAsum<F> {
@@ -13,7 +13,12 @@ pub trait IOperationAsum<F> {
 /// Describes a Axpy Operation.
 pub trait IOperationAxpy<F> {
     /// Computes the Axpy operation.
-    fn compute(&self, a: &SharedTensor<F>, x: & SharedTensor<F>, y: &mut SharedTensor<F>) -> Result<(), Error>;
+    fn compute(
+        &self,
+        a: &SharedTensor<F>,
+        x: &SharedTensor<F>,
+        y: &mut SharedTensor<F>,
+    ) -> Result<(), Error>;
 }
 
 /// Describes a Copy Operation.
@@ -25,7 +30,12 @@ pub trait IOperationCopy<F> {
 /// Describes a Dot Operation.
 pub trait IOperationDot<F> {
     /// Computes the Dot operation.
-    fn compute(&self, x: &SharedTensor<F>, y: &SharedTensor<F>, result: &mut SharedTensor<F>) -> Result<(), Error>;
+    fn compute(
+        &self,
+        x: &SharedTensor<F>,
+        y: &SharedTensor<F>,
+        result: &mut SharedTensor<F>,
+    ) -> Result<(), Error>;
 }
 
 /// Describes a Nrm2 Operation.
@@ -51,5 +61,17 @@ pub trait IOperationGemm<F> {
     /// Computes the Gemm operation.
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::many_single_char_names)]
-    fn compute(&self, alpha: &SharedTensor<F>, at: Transpose, a_dims: &[usize], a: &SharedTensor<F>, bt: Transpose, b_dims: &[usize], b: &SharedTensor<F>, beta: &SharedTensor<F>, c_dims: &[usize], c: &mut SharedTensor<F>) -> Result<(), ::coaster::error::Error>;
+    fn compute(
+        &self,
+        alpha: &SharedTensor<F>,
+        at: Transpose,
+        a_dims: &[usize],
+        a: &SharedTensor<F>,
+        bt: Transpose,
+        b_dims: &[usize],
+        b: &SharedTensor<F>,
+        beta: &SharedTensor<F>,
+        c_dims: &[usize],
+        c: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }

--- a/coaster-blas/src/plugin.rs
+++ b/coaster-blas/src/plugin.rs
@@ -86,12 +86,18 @@ pub trait Gbmv<F> {
     ///
     /// Saves the resulting vector into `c`.
     /// This is a Level 2 BLAS operation.
-   #[allow(clippy::too_many_arguments)]
-   fn gbmv(&self, alpha: &SharedTensor<F>,
-       at: Transpose, a: &SharedTensor<F>,
-       kl: &SharedTensor<F>, ku: &SharedTensor<F>,
-       x: &SharedTensor<F>, beta: &SharedTensor<F>, 
-       c: &mut SharedTensor<F>) -> Result<(), ::coaster::error::Error>;
+    #[allow(clippy::too_many_arguments)]
+    fn gbmv(
+        &self,
+        alpha: &SharedTensor<F>,
+        at: Transpose,
+        a: &SharedTensor<F>,
+        kl: &SharedTensor<u32>,
+        ku: &SharedTensor<u32>,
+        x: &SharedTensor<F>,
+        beta: &SharedTensor<F>,
+        c: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Provides the gemm operation.

--- a/coaster-blas/src/plugin.rs
+++ b/coaster-blas/src/plugin.rs
@@ -80,6 +80,20 @@ pub trait Swap<F> {
             -> Result<(), ::coaster::error::Error>;
 }
 
+/// Provides the gbmv operation
+pub trait Gbmv<F> {
+    /// Computes a matrix-vector product with a band matrix
+    ///
+    /// Saves the resulting vector into `c`.
+    /// This is a Level 2 BLAS operation.
+   #[allow(clippy::too_many_arguments)]
+   fn gbmv(&self, alpha: &SharedTensor<F>,
+       at: Transpose, a: &SharedTensor<F>,
+       kl: &SharedTensor<F>, ku: &SharedTensor<F>,
+       x: &SharedTensor<F>, beta: &SharedTensor<F>, 
+       c: &mut SharedTensor<F>) -> Result<(), ::coaster::error::Error>;
+}
+
 /// Provides the gemm operation.
 pub trait Gemm<F> {
     /// Computes a matrix-matrix product with general matrices.

--- a/coaster-blas/src/plugin.rs
+++ b/coaster-blas/src/plugin.rs
@@ -6,7 +6,7 @@ use coaster::binary::IBinary;
 use coaster::tensor::SharedTensor;
 
 /// Provides the functionality for a backend to support Basic Linear Algebra Subprogram operations.
-pub trait IBlas<F> { }
+pub trait IBlas<F> {}
 
 /// Provides the asum operation.
 pub trait Asum<F> {
@@ -14,8 +14,11 @@ pub trait Asum<F> {
     ///
     /// Saves the result to `result`.
     /// This is a Level 1 BLAS operation.
-    fn asum(&self, x: &SharedTensor<F>, result: &mut SharedTensor<F>)
-            -> Result<(), ::coaster::error::Error>;
+    fn asum(
+        &self,
+        x: &SharedTensor<F>,
+        result: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Provides the axpy operation.
@@ -24,8 +27,12 @@ pub trait Axpy<F> {
     ///
     /// Saves the resulting vector back into `y`.
     /// This is a Level 1 BLAS operation.
-    fn axpy(&self, a: &SharedTensor<F>, x: &SharedTensor<F>, y: &mut SharedTensor<F>)
-            -> Result<(), ::coaster::error::Error>;
+    fn axpy(
+        &self,
+        a: &SharedTensor<F>,
+        x: &SharedTensor<F>,
+        y: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Provides the copy operation.
@@ -34,8 +41,11 @@ pub trait Copy<F> {
     ///
     /// Saves the result to `y`.
     /// This is a Level 1 BLAS operation.
-    fn copy(&self, x: &SharedTensor<F>, y: &mut SharedTensor<F>)
-            -> Result<(), ::coaster::error::Error>;
+    fn copy(
+        &self,
+        x: &SharedTensor<F>,
+        y: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Provides the dot operation.
@@ -45,9 +55,12 @@ pub trait Dot<F> {
     ///
     /// Saves the resulting value into `result`.
     /// This is a Level 1 BLAS operation.
-    fn dot(&self, x: &SharedTensor<F>, y: &SharedTensor<F>,
-           result: &mut SharedTensor<F>)
-           -> Result<(), ::coaster::error::Error>;
+    fn dot(
+        &self,
+        x: &SharedTensor<F>,
+        y: &SharedTensor<F>,
+        result: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Provides the nrm2 operation.
@@ -56,8 +69,11 @@ pub trait Nrm2<F> {
     ///
     /// Saves the result to `result`.
     /// This is a Level 1 BLAS operation.
-    fn nrm2(&self, x: &SharedTensor<F>, result: &mut SharedTensor<F>)
-            -> Result<(), ::coaster::error::Error>;
+    fn nrm2(
+        &self,
+        x: &SharedTensor<F>,
+        result: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Provides the scal operation.
@@ -66,8 +82,11 @@ pub trait Scal<F> {
     ///
     /// Saves the resulting vector back into `x`.
     /// This is a Level 1 BLAS operation.
-    fn scal(&self, a: &SharedTensor<F>, x: &mut SharedTensor<F>)
-            -> Result<(), ::coaster::error::Error>;
+    fn scal(
+        &self,
+        a: &SharedTensor<F>,
+        x: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Provides the swap operation.
@@ -76,8 +95,11 @@ pub trait Swap<F> {
     ///
     /// Saves the resulting vector back into `x`.
     /// This is a Level 1 BLAS operation.
-    fn swap(&self, x: &mut SharedTensor<F>, y: &mut SharedTensor<F>)
-            -> Result<(), ::coaster::error::Error>;
+    fn swap(
+        &self,
+        x: &mut SharedTensor<F>,
+        y: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Provides the gbmv operation
@@ -107,11 +129,16 @@ pub trait Gemm<F> {
     /// Saves the result into `c`.
     /// This is a Level 3 BLAS operation.
     #[allow(clippy::too_many_arguments)]
-    fn gemm(&self, alpha: &SharedTensor<F>,
-            at: Transpose, a: &SharedTensor<F>,
-            bt: Transpose, b: &SharedTensor<F>,
-            beta: &SharedTensor<F>,
-            c: &mut SharedTensor<F>) -> Result<(), ::coaster::error::Error>;
+    fn gemm(
+        &self,
+        alpha: &SharedTensor<F>,
+        at: Transpose,
+        a: &SharedTensor<F>,
+        bt: Transpose,
+        b: &SharedTensor<F>,
+        beta: &SharedTensor<F>,
+        c: &mut SharedTensor<F>,
+    ) -> Result<(), ::coaster::error::Error>;
 }
 
 /// Allows a BlasBinary to be provided which is used for a IBlas implementation.
@@ -120,4 +147,4 @@ pub trait BlasBinaryProvider<F, B: IBlasBinary<F> + IBinary> {
     fn binary(&self) -> &B;
 }
 
-impl<F, B: IBlasBinary<F> + IBinary> IBlas<F> for dyn BlasBinaryProvider<F, B> { }
+impl<F, B: IBlasBinary<F> + IBinary> IBlas<F> for dyn BlasBinaryProvider<F, B> {}

--- a/coaster-blas/src/transpose.rs
+++ b/coaster-blas/src/transpose.rs
@@ -1,8 +1,8 @@
 //! Provides the Transpose functionality for Matrix operations.
 #[cfg(feature = "cuda")]
-use std::convert::From;
-#[cfg(feature = "cuda")]
 use crate::cublas::api::Operation;
+#[cfg(feature = "cuda")]
+use std::convert::From;
 
 #[derive(Debug, Copy, Clone)]
 /// Possible transpose operations that can be applied in Level 2 and Level 3 BLAS operations.

--- a/coaster-blas/tests/blas_specs.rs
+++ b/coaster-blas/tests/blas_specs.rs
@@ -209,24 +209,23 @@ where
 
     /*
      * The band matrix should look like this
-    write_to_tensor(&mut a, 
+    write_to_tensor(&mut a,
         &[
-          0.0, 0.5, 2.0, 
-          1.0, 0.5, 2.0, 
-          1.0, 0.5, 2.0, 
+          0.0, 0.5, 2.0,
+          1.0, 0.5, 2.0,
+          1.0, 0.5, 2.0,
           1.0, 0.5, 0.0,
-          0.0, 0.0, 0.0, 
+          0.0, 0.0, 0.0,
           0.0
         ]);
     */
 
-    write_to_tensor(&mut a,
-        &[ 0.5, 2.0, 0.0, 0.0,
-           1.0, 0.5, 2.0, 0.0,
-           0.0, 1.0, 0.5, 2.0,
-           0.0, 0.0, 1.0, 0.5,
-         ]);
-
+    write_to_tensor(
+        &mut a,
+        &[
+            0.5, 2.0, 0.0, 0.0, 1.0, 0.5, 2.0, 0.0, 0.0, 1.0, 0.5, 2.0, 0.0, 0.0, 1.0, 0.5,
+        ],
+    );
 
     write_to_tensor(&mut x, &[1., 2., 2., 1.]);
     write_to_tensor(&mut y, &[0.5, 1., 2., 3.]);
@@ -234,16 +233,9 @@ where
     write_to_tensor(&mut kl, &[1.0]);
     write_to_tensor(&mut ku, &[1.0]);
 
-    backend.gbmv(
-       &alpha,
-       Transpose::NoTrans,
-       &a,
-       &kl,
-       &ku,
-       &x,
-       &beta,
-       &mut y,
-    ).unwrap();
+    backend
+        .gbmv(&alpha, Transpose::NoTrans, &a, &kl, &ku, &x, &beta, &mut y)
+        .unwrap();
 
     tensor_assert_eq(&y, &[6.0, 9.0, 11., 11.5], 0.5);
 }
@@ -266,30 +258,23 @@ where
     write_to_tensor(&mut alpha, &[1.]);
     write_to_tensor(&mut beta, &[0.]);
 
-    write_to_tensor(&mut a, 
-        &[ 0.5, 2.0, 3.0, 0.0, 0.0, 0.0, 0.0,
-           1.0, 0.5, 2.0, 3.0, 0.0, 0.0, 0.0,
-           0.0, 1.0, 0.5, 2.0, 3.0, 0.0, 0.0,
-           0.0, 0.0, 1.0, 0.5, 2.0, 3.0, 0.0,
-        ]);
-
+    write_to_tensor(
+        &mut a,
+        &[
+            0.5, 2.0, 3.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.5, 2.0, 3.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.5,
+            2.0, 3.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.5, 2.0, 3.0, 0.0,
+        ],
+    );
 
     write_to_tensor(&mut x, &[1., 2., 3., 4., 5., 6., 7.]);
     write_to_tensor(&mut y, &[0., 0., 0., 0.]);
 
-    write_to_tensor(&mut kl, &[1.0]); 
+    write_to_tensor(&mut kl, &[1.0]);
     write_to_tensor(&mut ku, &[2.0]);
 
-    backend.gbmv(
-       &alpha,
-       Transpose::NoTrans,
-       &a,
-       &kl,
-       &ku,
-       &x,
-       &beta,
-       &mut y,
-    ).unwrap();
+    backend
+        .gbmv(&alpha, Transpose::NoTrans, &a, &kl, &ku, &x, &beta, &mut y)
+        .unwrap();
 
     tensor_assert_eq(&y, &[13.5, 20.0, 26.5, 33.0], 0.5);
 }
@@ -403,7 +388,7 @@ macro_rules! test_blas_gbmv {
                 test_gbmv2::<$t, _>($backend_getter());
             }
         }
-    }
+    };
 }
 
 test_blas!(native_f32, get_native_backend, f32);

--- a/coaster-blas/tests/blas_specs.rs
+++ b/coaster-blas/tests/blas_specs.rs
@@ -207,15 +207,12 @@ where
     write_to_tensor(&mut alpha, &[1.]);
     write_to_tensor(&mut beta, &[2.]);
 
-    write_to_tensor(&mut a, 
+    write_to_tensor(
+        &mut a,
         &[
-          0.0, 0.5, 2.0, 
-          2.0, 0.5, 2.0, 
-          2.0, 0.5, 2.0, 
-          2.0, 0.5, 0.0,
-          0.0, 0.0, 0.0, 
-          0.0
-        ]);
+            0.0, 0.5, 2.0, 2.0, 0.5, 2.0, 2.0, 0.5, 2.0, 2.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0,
+        ],
+    );
 
     write_to_tensor(&mut x, &[1., 2., 2., 1.]);
     write_to_tensor(&mut y, &[0.5, 1., 2., 3.]);
@@ -223,18 +220,10 @@ where
     write_to_tensor(&mut kl, &[1.0]);
     write_to_tensor(&mut ku, &[1.0]);
 
-    backend.gbmv(
-       &alpha,
-       Transpose::NoTrans,
-       &a,
-       &kl,
-       &ku,
-       &x,
-       &beta,
-       &mut y,
-    ).unwrap();
+    backend
+        .gbmv(&alpha, Transpose::NoTrans, &a, &kl, &ku, &x, &beta, &mut y)
+        .unwrap();
 
-    
     tensor_assert_eq(&y, &[5.5, 9., 11., 10.5], 0.5);
 }
 
@@ -342,7 +331,7 @@ macro_rules! test_blas_gbmv {
                 test_gbmv::<$t, _>($backend_getter());
             }
         }
-    }
+    };
 }
 
 test_blas!(native_f32, get_native_backend, f32);

--- a/coaster-blas/tests/blas_specs.rs
+++ b/coaster-blas/tests/blas_specs.rs
@@ -1,14 +1,14 @@
 #![cfg(feature = "native")] // required for data i/o
 
-extern crate coaster_blas as co_blas;
 extern crate coaster as co;
+extern crate coaster_blas as co_blas;
 
-use std::fmt;
 use crate::co::backend::{Backend, IBackend};
-use crate::co::framework::{IFramework};
+use crate::co::framework::IFramework;
+use std::fmt;
 
 use crate::co::plugin::numeric_helpers::{cast, Float, NumCast};
-use crate::co::tensor::{SharedTensor,ITensorDesc};
+use crate::co::tensor::{ITensorDesc, SharedTensor};
 use crate::co_blas::plugin::*;
 use crate::co_blas::transpose::Transpose;
 
@@ -33,8 +33,9 @@ fn get_cuda_backend() -> Backend<Cuda> {
 
 // TODO reuse the coaster-nn methods
 pub fn write_to_tensor<T>(xs: &mut SharedTensor<T>, data: &[f64])
-    where T: ::std::marker::Copy + NumCast {
-
+where
+    T: ::std::marker::Copy + NumCast,
+{
     assert_eq!(xs.desc().size(), data.len());
     let native = get_native_backend();
     let native_dev = native.device();
@@ -49,9 +50,10 @@ pub fn write_to_tensor<T>(xs: &mut SharedTensor<T>, data: &[f64])
 
 // TODO reuse the coaster-nn methods
 pub fn tensor_assert_eq<T>(xs: &SharedTensor<T>, data: &[f64], epsilon_mul: f64)
-    where T: Float + fmt::Debug + PartialEq + NumCast {
-
-	let e = 0. * epsilon_mul;
+where
+    T: Float + fmt::Debug + PartialEq + NumCast,
+{
+    let e = 0. * epsilon_mul;
 
     let native = get_native_backend();
     let native_dev = native.device();
@@ -65,17 +67,25 @@ pub fn tensor_assert_eq<T>(xs: &SharedTensor<T>, data: &[f64], epsilon_mul: f64)
         let diff = (x1_t - x2).abs();
         let max_diff = e * (x1_t.abs() + x2.abs()) * 0.5;
         if (x1_t - x2).abs() > e * (x1_t.abs() + x2.abs()) * 0.5 {
-            println!("Results differ: {:?} != {:?} ({:.2?} in {:?} and {:?}",
-                     x1_t, x2, diff / max_diff, mem_slice, data);
+            println!(
+                "Results differ: {:?} != {:?} ({:.2?} in {:?} and {:?}",
+                x1_t,
+                x2,
+                diff / max_diff,
+                mem_slice,
+                data
+            );
             assert!(false);
         }
     }
 }
 
 pub fn test_asum<T, F>(backend: Backend<F>)
-    where T: Float + fmt::Debug,
-            F: IFramework,
-            Backend<F>: Asum<T> + IBackend {
+where
+    T: Float + fmt::Debug,
+    F: IFramework,
+    Backend<F>: Asum<T> + IBackend,
+{
     let mut x = SharedTensor::<T>::new(&[3]);
     let mut result = SharedTensor::<T>::new(&[1]);
     write_to_tensor(&mut x, &[1.0, -2.0, 3.0]);
@@ -85,9 +95,11 @@ pub fn test_asum<T, F>(backend: Backend<F>)
 }
 
 pub fn test_axpy<T, F>(backend: Backend<F>)
-    where T: Float + fmt::Debug,
-            F: IFramework,
-            Backend<F>: Axpy<T> + IBackend {
+where
+    T: Float + fmt::Debug,
+    F: IFramework,
+    Backend<F>: Axpy<T> + IBackend,
+{
     let mut a = SharedTensor::<T>::new(&[1]);
     let mut x = SharedTensor::<T>::new(&[3]);
     let mut y = SharedTensor::<T>::new(&[3]);
@@ -101,9 +113,11 @@ pub fn test_axpy<T, F>(backend: Backend<F>)
 }
 
 pub fn test_copy<T, F>(backend: Backend<F>)
-    where T: Float + fmt::Debug,
-            F: IFramework,
-            Backend<F>: Copy<T> + IBackend {
+where
+    T: Float + fmt::Debug,
+    F: IFramework,
+    Backend<F>: Copy<T> + IBackend,
+{
     let mut x = SharedTensor::<T>::new(&[3]);
     let mut y = SharedTensor::<T>::new(&[3]);
     write_to_tensor(&mut x, &[1., 2., 3.]);
@@ -113,9 +127,11 @@ pub fn test_copy<T, F>(backend: Backend<F>)
 }
 
 pub fn test_dot<T, F>(backend: Backend<F>)
-    where T: Float + fmt::Debug,
-            F: IFramework,
-            Backend<F>: Dot<T> + IBackend {
+where
+    T: Float + fmt::Debug,
+    F: IFramework,
+    Backend<F>: Dot<T> + IBackend,
+{
     let mut x = SharedTensor::<T>::new(&[3]);
     let mut y = SharedTensor::<T>::new(&[3]);
     let mut result = SharedTensor::<T>::new(&[1]);
@@ -127,9 +143,11 @@ pub fn test_dot<T, F>(backend: Backend<F>)
 }
 
 pub fn test_nrm2<T, F>(backend: Backend<F>)
-    where T: Float + fmt::Debug,
-            F: IFramework,
-            Backend<F>: Nrm2<T> + IBackend {
+where
+    T: Float + fmt::Debug,
+    F: IFramework,
+    Backend<F>: Nrm2<T> + IBackend,
+{
     let mut x = SharedTensor::<T>::new(&[3]);
     let mut result = SharedTensor::<T>::new(&[1]);
     write_to_tensor(&mut x, &[1., 2., 2.]);
@@ -139,9 +157,11 @@ pub fn test_nrm2<T, F>(backend: Backend<F>)
 }
 
 pub fn test_scal<T, F>(backend: Backend<F>)
-    where T: Float + fmt::Debug,
-            F: IFramework,
-            Backend<F>: Scal<T> + IBackend {
+where
+    T: Float + fmt::Debug,
+    F: IFramework,
+    Backend<F>: Scal<T> + IBackend,
+{
     let mut a = SharedTensor::<T>::new(&[1]);
     let mut y = SharedTensor::<T>::new(&[3]);
     write_to_tensor(&mut a, &[2.]);
@@ -153,9 +173,11 @@ pub fn test_scal<T, F>(backend: Backend<F>)
 }
 
 pub fn test_swap<T, F>(backend: Backend<F>)
-    where T: Float + fmt::Debug,
-            F: IFramework,
-            Backend<F>: Swap<T> + IBackend {
+where
+    T: Float + fmt::Debug,
+    F: IFramework,
+    Backend<F>: Swap<T> + IBackend,
+{
     let mut x = SharedTensor::<T>::new(&[3]);
     let mut y = SharedTensor::<T>::new(&[3]);
     write_to_tensor(&mut x, &[1., 2., 3.]);
@@ -217,36 +239,47 @@ where
 }
 
 pub fn test_gemm<T, F>(backend: Backend<F>)
-    where T: Float + fmt::Debug,
-            F: IFramework,
-            Backend<F>: Gemm<T> + IBackend {
+where
+    T: Float + fmt::Debug,
+    F: IFramework,
+    Backend<F>: Gemm<T> + IBackend,
+{
     let mut alpha = SharedTensor::<T>::new(&[1]);
     let mut beta = SharedTensor::<T>::new(&[1]);
     let mut a = SharedTensor::<T>::new(&[3, 2]);
     let mut b = SharedTensor::<T>::new(&[2, 3]);
     write_to_tensor(&mut alpha, &[1.]);
     write_to_tensor(&mut beta, &[0.]);
-    write_to_tensor(&mut a, &[2., 5., 2.,  5., 2., 5.]);
-    write_to_tensor(&mut b, &[4., 1., 1.,  4., 1., 1.]);
+    write_to_tensor(&mut a, &[2., 5., 2., 5., 2., 5.]);
+    write_to_tensor(&mut b, &[4., 1., 1., 4., 1., 1.]);
 
     let mut c = SharedTensor::<T>::new(&[3, 3]);
-    backend.gemm(&alpha,
-                    Transpose::NoTrans, &a,
-                    Transpose::NoTrans, &b,
-                    &beta,
-                    &mut c).unwrap();
+    backend
+        .gemm(
+            &alpha,
+            Transpose::NoTrans,
+            &a,
+            Transpose::NoTrans,
+            &b,
+            &beta,
+            &mut c,
+        )
+        .unwrap();
 
-    tensor_assert_eq(&c, &[
-        28.0, 7.0, 7.0,
-        28.0, 7.0, 7.0,
-        28.0, 7.0, 7.0], 0.);
+    tensor_assert_eq(&c, &[28.0, 7.0, 7.0, 28.0, 7.0, 7.0, 28.0, 7.0, 7.0], 0.);
 
     let mut d = SharedTensor::<T>::new(&[2, 2]);
-    backend.gemm(&alpha,
-                    Transpose::Trans, &a,
-                    Transpose::Trans, &b,
-                    &beta,
-                    &mut d).unwrap();
+    backend
+        .gemm(
+            &alpha,
+            Transpose::Trans,
+            &a,
+            Transpose::Trans,
+            &b,
+            &beta,
+            &mut d,
+        )
+        .unwrap();
 
     tensor_assert_eq(&d, &[12.0, 12.0, 30.0, 30.0], 0.);
 }
@@ -292,11 +325,6 @@ macro_rules! test_blas {
             }
 
             #[test]
-            fn it_computes_correct_gbmv() {
-                test_gbmv::<$t, _>($backend_getter());
-            }
-
-            #[test]
             fn it_computes_correct_gemm() {
                 test_gemm::<$t, _>($backend_getter());
             }
@@ -304,8 +332,25 @@ macro_rules! test_blas {
     };
 }
 
+macro_rules! test_blas_gbmv {
+    ($mod_name:ident, $backend_getter:ident, $t:ident) => {
+        mod $mod_name {
+            use super::*;
+
+            #[test]
+            fn it_computes_correct_gbmv() {
+                test_gbmv::<$t, _>($backend_getter());
+            }
+        }
+    }
+}
+
 test_blas!(native_f32, get_native_backend, f32);
 test_blas!(native_f64, get_native_backend, f64);
+
+// This is temporary until CUDA impelements Gbmv trait
+test_blas_gbmv!(native_f32_gbmv, get_native_backend, f32);
+test_blas_gbmv!(native_f64_gbmv, get_native_backend, f64);
 
 #[cfg(feature = "cuda")]
 test_blas!(cuda_f32, get_cuda_backend, f32);

--- a/rust-blas/src/math/bandmat.rs
+++ b/rust-blas/src/math/bandmat.rs
@@ -75,6 +75,38 @@ impl<T> BandMat<T> {
         self.data.push(val);
     }
 
+    /// Converts a standard matrix into a band matrix
+    ///
+    /// TODO: write a conversion utility
+    /// DOES NOT PERFORM CONVERSION INTO BAND MATRIX FORMAT
+    ///
+    /// The actual conversion can be done by hand once one
+    /// understands the pattern of the band matrix. Say you
+    /// have an MxN band matrix in standard form. Say you 
+    /// have ku upper diagonals and kl sub diagonals. Then
+    /// the band matrix representation will have dimensions 
+    /// Nx(ku+kl+1), and will have the all of the relevant 
+    /// values of each row, concatenated starting at position
+    /// kl. An example is probably useful:
+    ///
+    /// Say our initial matrix is the following:
+    ///
+    /// [ 1 2 0 0 ]
+    /// [ 3 1 2 0 ]
+    /// [ 0 3 1 2 ]
+    /// [ 0 0 3 1 ]
+    ///
+    /// Then the band matrix representation would be:
+    ///
+    /// [ x 1 2 ]
+    /// [ 3 1 2 ]
+    /// [ 3 1 2 ]
+    /// [ 3 1 x ]
+    ///
+    /// "x" represent values that aren't relevant to the 
+    /// calculations: the values in those slots won't be
+    /// read or modified by the underlying BLAS program.
+    ///
     pub fn from_matrix(
         mat: Mat<T>,
         sub_diagonals: u32,
@@ -84,7 +116,6 @@ impl<T> BandMat<T> {
         
         let v = unsafe {
             let length = mat.cols() * mat.rows();
-            //Self::put_in_band_fmt(&mut data, mat.rows(), mat.cols(), sub_diagonals, sup_diagonals);
             Vec::from_raw_parts(mat.as_mut_ptr(), length, length)
         };
 

--- a/rust-blas/src/math/mat.rs
+++ b/rust-blas/src/math/mat.rs
@@ -19,6 +19,15 @@ pub struct Mat<T> {
 }
 
 impl<T> Mat<T> {
+
+    pub fn new_from_data(rows: usize, cols: usize, data: Vec<T>) -> Mat<T> {
+        Mat {
+            rows,
+            cols,
+            data
+        }
+    }
+    
     pub fn new(n: usize, m: usize) -> Mat<T> {
         let len = n * m;
         let mut data = Vec::with_capacity(len);
@@ -26,11 +35,7 @@ impl<T> Mat<T> {
             data.set_len(len);
         }
 
-        Mat {
-            rows: n,
-            cols: m,
-            data,
-        }
+        Self::new_from_data(n, m, data)
     }
 
     pub fn rows(&self) -> usize {

--- a/rust-blas/src/math/mat.rs
+++ b/rust-blas/src/math/mat.rs
@@ -19,15 +19,10 @@ pub struct Mat<T> {
 }
 
 impl<T> Mat<T> {
-
     pub fn new_from_data(rows: usize, cols: usize, data: Vec<T>) -> Mat<T> {
-        Mat {
-            rows,
-            cols,
-            data
-        }
+        Mat { rows, cols, data }
     }
-    
+
     pub fn new(n: usize, m: usize) -> Mat<T> {
         let len = n * m;
         let mut data = Vec::with_capacity(len);

--- a/rust-blas/src/matrix/mod.rs
+++ b/rust-blas/src/matrix/mod.rs
@@ -35,7 +35,6 @@ pub trait Matrix<T> {
 pub trait BandMatrix<T>: Matrix<T> {
     fn sub_diagonals(&self) -> u32;
     fn sup_diagonals(&self) -> u32;
-    fn original_dims(&self) -> &Vec<usize>;
 
     fn as_matrix(&self) -> &dyn Matrix<T>;
 }

--- a/rust-blas/src/matrix/mod.rs
+++ b/rust-blas/src/matrix/mod.rs
@@ -35,6 +35,7 @@ pub trait Matrix<T> {
 pub trait BandMatrix<T>: Matrix<T> {
     fn sub_diagonals(&self) -> u32;
     fn sup_diagonals(&self) -> u32;
+    fn original_dims(&self) -> &Vec<usize>;
 
     fn as_matrix(&self) -> &dyn Matrix<T>;
 }


### PR DESCRIPTION
Added the Gbmv BLAS operation trait, and implemented it for the Native backend.

Also applied `cargo fmt` to the `coaster-blas` project, which accounts for the majority of changes. If this is too much, we can revert that commit.