### PR TITLE
chore/examples: update juice version

### DIFF
--- a/juice-examples/Cargo.toml
+++ b/juice-examples/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 greenglas = { version = "0.2" }
-juice = { version = "0.2", default-features = false }
+juice = { version = "0.2.3", default-features = false }
 coaster = { version = "0.1", default-features = false }
 coaster-nn = { version = "0.4.1", default-features = false }
 


### PR DESCRIPTION
Motivation for this is that the old juice version loads an old version of bindgen, which loads in syntex_syntax, which has macros that compile on and off on rust versions. 