### PR TITLE
docs/coaster: documentation lives under .io domain

### DIFF
--- a/coaster/README.md
+++ b/coaster/README.md
@@ -46,7 +46,7 @@ For more information,
 [spearow]: https://spearow.io/project/juice
 [juice]: https://github.com/spearow/juice
 [spearow]: https://spearow.io/projects/coaster
-[documentation]: https://spearow.github.com/coaster
+[documentation]: https://spearow.github.io/coaster
 
 ## Getting Started
 


### PR DESCRIPTION

## What does this PR accomplish?

Makes the coaster documentation link work.

 * 📙 Documentation

Closes #127 .

## Changes proposed by this PR:

Change github.com to github.io

## 📜 Checklist

 * [x] Test coverage is excellent
 * [x] _All_ unit tests pass
 * [x] The `juice-examples` run just fine
 * [x] Documentation is thorough, extensive and explicit
