### PR TITLE
fix/book: links pointed into the 404-void

### DIFF
--- a/juice/doc/book.toml
+++ b/juice/doc/book.toml
@@ -24,3 +24,11 @@ boost-hierarchy = 2
 boost-paragraph = 1
 expand = true
 heading-split-level = 2
+
+[output.linkcheck]
+follow-web-links = true
+cache-timeout = 43200
+warning-policy = "warn"
+
+[output.linkcheck.http-headers]
+'crates\.io' = ["Accept: text/html"]

--- a/juice/doc/src/api-docs.md
+++ b/juice/doc/src/api-docs.md
@@ -1,6 +1,6 @@
 
 # Rust API Documentation
 
-The latest and greatest [API Documentation](api-docs) based on the current git master status.
+The latest and greatest [API Documentation][api-docs] based on the current git master status.
 
 [api-docs]: https://spearow.github.io/juice/juice/index.html

--- a/juice/doc/src/juice.md
+++ b/juice/doc/src/juice.md
@@ -12,7 +12,7 @@ you can build classical machine as well as deep learning and other fancy machine
 intelligence applications.
 
 Juice was inspired by the brilliant people behind TensorFlow, Torch, Caffe,
-[Rust](rust) and numerous research papers and brings modularity, performance and
+[Rust][rust] and numerous research papers and brings modularity, performance and
 portability to deep learning.
 
 <br/>
@@ -64,7 +64,7 @@ Learn more at chapter [4. Backend](./backend.html) or at the
 ## Contributing
 
 Want to contribute? Awesome!
-[We have instructions to help you get started](https://github.com/spearow/juice/blob/master/CONTRIBUTING.md).
+[We have instructions to help you get started](https://github.com/spearow/juice/blob/master/juice/CONTRIBUTING.md).
 
 Juice has a near real-time collaboration culture, which happens at the [Github
 repository](https://github.com/spearow/juice) and on the
@@ -82,9 +82,6 @@ just want a more low-level overview.
 
 Juice is free for anyone for whatever purpose.
 Juice is licensed under either
-[Apache License v2.0](https://github.com/spearow/juice/blob/master/LICENSE-APACHE) or,
-[MIT license](https://github.com/spearow/juice/blob/master/LICENSE-MIT).
+[Apache License v2.0](https://github.com/spearow/juice/blob/master/juice/LICENSE-APACHE) or,
+[MIT license](https://github.com/spearow/juice/blob/master/juice/LICENSE-MIT).
 Whatever strikes your fancy.
-
-
-

--- a/juice/doc/src/layers.md
+++ b/juice/doc/src/layers.md
@@ -3,15 +3,15 @@
 ### What is a Layer?
 
 [Layers](./deep-learning-glossary.html#Layer) are the only building
-blocks in Juice. As we will see later on, everything is a layer. Even when 
-we construct [networks](./deep-learning-glossary.html#Network), we are still just 
+blocks in Juice. As we will see later on, everything is a layer. Even when
+we construct [networks](./deep-learning-glossary.html#Network), we are still just
 working with layers composed of smaller layers. This makes the API clean and expressive.
 
-A layer is like a function: given an input it computes an output. 
-It could be some mathematical expression, like Sigmoid, ReLU, or a non-mathematical instruction, 
+A layer is like a function: given an input it computes an output.
+It could be some mathematical expression, like Sigmoid, ReLU, or a non-mathematical instruction,
 like querying data from a database, logging data, or anything in between.
 In Juice, layers describe not only the interior 'hidden layers' but also the input and
-output layer. 
+output layer.
 
 Layers in Juice are only slightly opinionated, they need to take
 an input and produce an output. This is required in order to successfully stack
@@ -38,7 +38,7 @@ let linear_network_with_one_layer: Layer = Layer::from_config(backend, &linear_1
 
 Hurray! We just constructed a [network](./deep-learning-glossary.html#Network)
 with one layer. (In the following chapter we will learn how to create more
-powerful networks). 
+powerful networks).
 
 The `from_config` method initializes a `Layer`, which wraps the specific implementation (a struct that has  [`ILayer`(/src/layer.rs)][ilayer] implemented) in a worker field.
 In the tiny example above, the worker field of the `linear_network_with_one_layer`
@@ -49,10 +49,10 @@ introduces the specific behaviour of the layer.
 In the following chapters we explore more about how we can construct
 real-world networks, the layer lifecycle and how we can add new layers to the Juice framework.
 
-[layer-config]: https://github.com/spearow/juice/blob/master/src/layer.rs
-[layer]: https://github.com/spearow/juice/blob/master/src/layer.rs
-[ilayer]: https://github.com/spearow/juice/blob/master/src/layer.rs
-[linear-layer]: https://github.com/spearow/juice/blob/master/src/layers/common/linear.rs
+[layer-config]: https://github.com/spearow/juice/blob/master/juice/src/layer.rs
+[layer]: https://github.com/spearow/juice/blob/master/juice/src/layer.rs
+[ilayer]: https://github.com/spearow/juice/blob/master/juice/src/layer.rs
+[linear-layer]: https://github.com/spearow/juice/blob/master/juice/src/layers/common/linear.rs
 
 ### What can Layers do?
 
@@ -81,7 +81,7 @@ and are a fundamental piece in neural networks.
 
 Examples of activation layers are `Sigmoid`, `TanH` or `ReLU`. All available
 activation layers can be found at
-[src/layers/activation](https://github.com/spearow/juice/tree/master/src/layers/activation).
+[src/layers/activation](https://github.com/spearow/juice/tree/master/juice/src/layers/activation).
 
 #### Loss Layers
 
@@ -90,7 +90,7 @@ Loss layers are often the last layer in a network.
 
 Examples of loss layers are `Hinge Loss`, `Softmax Loss` or `Negative Log
 Likelihood`. All available loss layers can be found at
-[src/layers/loss](https://github.com/spearow/juice/tree/master/src/layers/loss).
+[src/layers/loss](https://github.com/spearow/juice/tree/master/juice/src/layers/loss).
 
 #### Common Layers
 
@@ -99,7 +99,7 @@ anything that is not an activation or loss layer.
 
 Examples of common layers are `fully-connected`, `convolutional`, `pooling`, `LSTM`,
 etc. All available common layers can be found at
-[src/layers/common](https://github.com/spearow/juice/tree/master/src/layers/common).
+[src/layers/common](https://github.com/spearow/juice/tree/master/juice/src/layers/common).
 
 #### Utility Layers
 
@@ -111,7 +111,7 @@ like the other types.
 
 Examples of Utility layers are `Reshape`, `Flatten` or `Normalization`. All
 available utility layers can be found at
-[src/layers/utility](https://github.com/spearow/juice/tree/master/src/layers/utility).
+[src/layers/utility](https://github.com/spearow/juice/tree/master/juice/src/layers/utility).
 
 #### Container Layers
 
@@ -122,7 +122,7 @@ Container layers differ in how they connect the layers that it receives.
 
 Examples of container layers are `Sequential`. All available container layers
 can be found at
-[src/layers/container](https://github.com/spearow/juice/tree/master/src/layers/container).
+[src/layers/container](https://github.com/spearow/juice/tree/master/juice/src/layers/container).
 
 ### Why Layers?
 

--- a/juice/doc/src/solvers.md
+++ b/juice/doc/src/solvers.md
@@ -31,5 +31,5 @@ let mut solver = Solver::from_config(backend.clone(), backend.clone(), &solver_c
 
 The now initialized `Solver` can be feed with data to optimize the `network`.
 
-[solver]: https://github.com/spearow/juice/blob/master/src/solver/mod.rs
-[solver-config]: https://github.com/spearow/juice/blob/master/src/solver/mod.rs
+[solver]: https://github.com/spearow/juice/blob/master/juice/src/solver/mod.rs
+[solver-config]: https://github.com/spearow/juice/blob/master/juice/src/solver/mod.rs


### PR DESCRIPTION
Use mdbook-linkcheck plugin from now on to prevent link
decay.

<!--
Thank you for submitting a PR to juice!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix
 * 📙 Documentation

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #130 .

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [x] Test coverage is excellent
 * [x] _All_ unit tests pass
 * [x] The `juice-examples` run just fine
 * [x] Documentation is thorough, extensive and explicit
