### PR TITLE
remove trailing semicolon in macro warning

### DIFF
--- a/coaster-blas/src/frameworks/native.rs
+++ b/coaster-blas/src/frameworks/native.rs
@@ -12,19 +12,19 @@ use rblas::matrix::Matrix;
 
 macro_rules! read {
     ($x:ident, $t:ident, $slf:ident) => {
-        $x.read($slf.device())?.as_slice::<$t>();
+        $x.read($slf.device())?.as_slice::<$t>()
     };
 }
 
 macro_rules! read_write {
     ($x:ident, $t: ident, $slf:ident) => {
-        $x.read_write($slf.device())?.as_mut_slice::<$t>();
+        $x.read_write($slf.device())?.as_mut_slice::<$t>()
     };
 }
 
 macro_rules! write_only {
     ($x:ident, $t: ident, $slf:ident) => {
-        $x.write_only($slf.device())?.as_mut_slice::<$t>();
+        $x.write_only($slf.device())?.as_mut_slice::<$t>()
     };
 }
 


### PR DESCRIPTION
```
   --> coaster-blas/src/frameworks/native.rs:27:59
    |
27  |         $x.write_only($slf.device())?.as_mut_slice::<$t>();
    |                                                           ^
...
253 | impl_iblas_for!(f32, Backend<Native>);
    | ------------------------------------- in this macro invocation
    |
    = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `write_only` (in Nightly builds, run with -Z macro-backtrace for more info)
```
<!--
Thank you for submitting a PR to juice!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🪣 Misc

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

remove trailing semicolon in macro warning

## 📜 Checklist

 * [x] Test coverage is excellent
 * [x] _All_ unit tests pass
 * [x] The `juice-examples` run just fine
 * [x] Documentation is thorough, extensive and explicit
