### PR TITLE
Fix rcublas deps for tests

### DIFF
--- a/rcublas/cublas/Cargo.toml
+++ b/rcublas/cublas/Cargo.toml
@@ -22,4 +22,5 @@ log = "0.4"
 thiserror = "1.0"
 
 [dev-dependencies]
+coaster = { path = "../../coaster", features = ["cuda"] }
 env_logger = "0.9"


### PR DESCRIPTION
## What does this PR accomplish?

Fix `cargo test` which was failing before due to missing `coaster` deps for `rcublas/cublas`.

 * 🩹 Bug Fix

## Changes proposed by this PR:

Add `coaster` as a dev dep to `rcublas/cublas`.

## 📜 Checklist

 * [x] _All_ unit tests pass
