### PR TITLE
Fix Linear layer bias gradient computation; add size checks to CUDA functions

### DIFF
--- a/coaster-blas/src/frameworks/cuda/helper.rs
+++ b/coaster-blas/src/frameworks/cuda/helper.rs
@@ -251,7 +251,7 @@ macro_rules! iblas_gemm_for_cuda {
             beta: &SharedTensor<$t>,
             c: &mut SharedTensor<$t>,
         ) -> Result<(), ::coaster::error::Error> {
-            use Transpose as T;
+            use Transpose::{NoTrans, ConjTrans, Trans};
 
             // Determine the dimensions of all the matrices.
             // We always treat the first dimension as the number of rows and all


### PR DESCRIPTION
## What does this PR accomplish?

 * 🩹 Bug Fix

Closes #169 

## Changes proposed by this PR:

1. Add an assert to CUDA `copy()` function to check that source and destination have the same size.
2. Add an assert to CUDA `gemm()` function to check that computed matrix multiplication dimensions match the passed tensor sizes.
3. Fix the Linear layer bias gradient computation by summing all gradients in the batch instead of copying the output gradient to the bias gradient (which is incorrect since the output gradient contains N items, not 1).

After this change, `cuda-memcheck` no longer finds errors.

## Notes to reviewer:

All unit tests continue to pass except `ui` which is also broken at HEAD.

## 📜 Checklist

 * [x] The `juice-examples` run just fine
