### PR TITLE
Fix coaster UI tests (rustc error messages changed in 1.62)

### DIFF
--- a/coaster/src/frameworks/native/flatbox.rs
+++ b/coaster/src/frameworks/native/flatbox.rs
@@ -43,7 +43,7 @@ impl FlatBox {
 impl Drop for FlatBox {
     fn drop(&mut self) {
         unsafe {
-            Box::from_raw(self.raw_box);
+            drop(Box::from_raw(self.raw_box));
         }
     }
 }

--- a/coaster/tests/ui/err-02-drop_live_memory.stderr
+++ b/coaster/tests/ui/err-02-drop_live_memory.stderr
@@ -2,9 +2,9 @@ error[E0499]: cannot borrow `*x` as mutable more than once at a time
   --> $DIR/err-02-drop_live_memory.rs:9:5
    |
 8  |     let m = x.write_only(&dev).unwrap();
-   |             - first mutable borrow occurs here
+   |             ------------------ first mutable borrow occurs here
 9  |     x.drop(&dev);
-   |     ^ second mutable borrow occurs here
+   |     ^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 13 |     let _foo = m;
    |                - first borrow later used here

--- a/coaster/tests/ui/err-05-read_write_borrows.stderr
+++ b/coaster/tests/ui/err-05-read_write_borrows.stderr
@@ -2,9 +2,9 @@ error[E0502]: cannot borrow `*x` as immutable because it is also borrowed as mut
   --> $DIR/err-05-read_write_borrows.rs:9:14
    |
 8  |     let m1 = x.write_only(&dev).unwrap();
-   |              - mutable borrow occurs here
+   |              ------------------ mutable borrow occurs here
 9  |     let m2 = x.read(&dev).unwrap();
-   |              ^ immutable borrow occurs here
+   |              ^^^^^^^^^^^^ immutable borrow occurs here
 ...
 13 |     let _foo = m1;
    |                -- mutable borrow later used here

--- a/coaster/tests/ui/err-06-two_write_borrows.stderr
+++ b/coaster/tests/ui/err-06-two_write_borrows.stderr
@@ -2,9 +2,9 @@ error[E0499]: cannot borrow `*x` as mutable more than once at a time
   --> $DIR/err-06-two_write_borrows.rs:9:14
    |
 8  |     let m1 = x.write_only(&dev).unwrap();
-   |              - first mutable borrow occurs here
+   |              ------------------ first mutable borrow occurs here
 9  |     let m2 = x.write_only(&dev).unwrap();
-   |              ^ second mutable borrow occurs here
+   |              ^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 13 |     let _foo = m1;
    |                -- first borrow later used here


### PR DESCRIPTION
## What does this PR accomplish?

 * 🪣 Misc

## Changes proposed by this PR:

Fix coaster UI tests golden output which expect exact compiler error messages, which format has changed in recent rustc versions.

## 📜 Checklist

 * [x] _All_ unit tests pass
