### PR TITLE
Coaster convolution API cleanup

### DIFF
--- a/coaster-nn/src/frameworks/cuda/mod.rs
+++ b/coaster-nn/src/frameworks/cuda/mod.rs
@@ -667,7 +667,14 @@ where
     }
 }
 
-impl<T> RnnConfig<T> for crate::cudnn::utils::RnnConfig where T: Float + DataTypeInfo {}
+impl<T> RnnConfig<T> for crate::cudnn::utils::RnnConfig
+where
+    T: Float + DataTypeInfo,
+{
+    fn workspace_size(&self) -> usize {
+        self.largest_workspace_size()
+    }
+}
 
 impl RnnInputMode {
     fn as_cudnn(&self) -> Result<cudnnRNNInputMode_t, Error> {

--- a/coaster-nn/src/frameworks/cuda/mod.rs
+++ b/coaster-nn/src/frameworks/cuda/mod.rs
@@ -486,9 +486,8 @@ where
     }
 }
 
-impl<T> ConvolutionContext<T> for crate::cudnn::utils::ConvolutionContext
-where
-    T: Float + DataTypeInfo,
+impl<T> ConvolutionContext<T> for crate::cudnn::utils::ConvolutionContext where
+    T: Float + DataTypeInfo
 {
 }
 
@@ -668,11 +667,7 @@ where
     }
 }
 
-impl<T> RnnConfig<T> for crate::cudnn::utils::RnnConfig
-where
-    T: Float + DataTypeInfo,
-{
-}
+impl<T> RnnConfig<T> for crate::cudnn::utils::RnnConfig where T: Float + DataTypeInfo {}
 
 impl RnnInputMode {
     fn as_cudnn(&self) -> Result<cudnnRNNInputMode_t, Error> {

--- a/coaster-nn/src/frameworks/cuda/mod.rs
+++ b/coaster-nn/src/frameworks/cuda/mod.rs
@@ -417,7 +417,7 @@ impl<T> NN<T> for Backend<Cuda>
 where
     T: Float + DataTypeInfo,
 {
-    type CC = utils::ConvolutionConfig;
+    type CC = utils::ConvolutionContext;
     type CLRN = utils::NormalizationConfig;
     type CPOOL = utils::PoolingConfig;
     type CDROP = utils::DropoutConfig;
@@ -428,7 +428,7 @@ where
     }
 }
 
-impl<'a, T> NNOperationConfig<T> for utils::ConvolutionConfig where T: Float + DataTypeInfo {}
+impl<'a, T> NNOperationConfig<T> for utils::ConvolutionContext where T: Float + DataTypeInfo {}
 impl<T> NNOperationConfig<T> for utils::RnnConfig where T: Float + DataTypeInfo {}
 impl<T> NNOperationConfig<T> for utils::NormalizationConfig where T: Float + DataTypeInfo {}
 impl<T> NNOperationConfig<T> for utils::PoolingConfig where T: Float + DataTypeInfo {}
@@ -486,20 +486,17 @@ where
     }
 }
 
-impl<T> ConvolutionConfig<T> for crate::cudnn::utils::ConvolutionConfig
+impl<T> ConvolutionContext<T> for crate::cudnn::utils::ConvolutionContext
 where
     T: Float + DataTypeInfo,
 {
-    fn workspace_size(&self) -> usize {
-        self.largest_workspace_size()
-    }
 }
 
 impl<T> Convolution<T> for Backend<Cuda>
 where
     T: Float + DataTypeInfo,
 {
-    fn new_convolution_config(
+    fn new_convolution_context(
         &self,
         src: &SharedTensor<T>,
         dest: &SharedTensor<T>,
@@ -581,7 +578,7 @@ where
             workspace_size_bwd_data = 8;
         }
 
-        Ok(crate::cudnn::utils::ConvolutionConfig::new(
+        Ok(crate::cudnn::utils::ConvolutionContext::new(
             useable_algo_fwd.as_cudnn().unwrap(),
             workspace_size_fwd,
             useable_algo_bwd_filter.as_cudnn().unwrap(),
@@ -598,8 +595,7 @@ where
         filter: &SharedTensor<T>,
         x: &SharedTensor<T>,
         result: &mut SharedTensor<T>,
-        workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), Error> {
         let cudnn_framework = self.framework().cudnn();
         let scal_params: crate::cudnn::utils::ScalParams<T> =
@@ -609,11 +605,9 @@ where
         let f_mem = read!(filter, self);
         let x_mem = read!(x, self);
         let r_mem = write_only!(result, self);
-        let w_mem = write_only!(workspace, self);
 
         exec2!(cudnn_framework.convolution_forward(
-            config,
-            trans_mut!(w_mem),
+            context,
             trans!(f_mem),
             &x.cudnn_tensor_desc()?, // src_desc
             trans!(x_mem),
@@ -628,8 +622,7 @@ where
         src_data: &SharedTensor<T>,
         dest_diff: &SharedTensor<T>,
         filter_diff: &mut SharedTensor<T>,
-        workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), Error> {
         let cudnn_framework = self.framework().cudnn();
         let scal_params: crate::cudnn::utils::ScalParams<T> =
@@ -637,10 +630,8 @@ where
         let s_mem = read!(src_data, self);
         let dd_mem = read!(dest_diff, self);
         let df_mem = write_only!(filter_diff, self);
-        let w_mem = write_only!(workspace, self);
         exec2!(cudnn_framework.convolution_backward_filter(
-            config,
-            trans_mut!(w_mem),
+            context,
             &src_data.cudnn_tensor_desc()?,
             trans!(s_mem),
             &dest_diff.cudnn_tensor_desc()?,
@@ -655,8 +646,7 @@ where
         filter: &SharedTensor<T>,
         x_diff: &SharedTensor<T>,
         result_diff: &mut SharedTensor<T>,
-        workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), Error> {
         let cudnn_framework = self.framework().cudnn();
         let scal_params: crate::cudnn::utils::ScalParams<T> =
@@ -666,10 +656,8 @@ where
         let f_mem = read!(filter, self);
         let dx_mem = read!(x_diff, self);
         let dr_mem = write_only!(result_diff, self);
-        let w_mem = write_only!(workspace, self);
         exec2!(cudnn_framework.convolution_backward_data(
-            config,
-            trans_mut!(w_mem),
+            context,
             trans!(f_mem),
             &x_diff.cudnn_tensor_desc()?,
             trans!(dx_mem),
@@ -684,9 +672,6 @@ impl<T> RnnConfig<T> for crate::cudnn::utils::RnnConfig
 where
     T: Float + DataTypeInfo,
 {
-    fn workspace_size(&self) -> usize {
-        self.largest_workspace_size()
-    }
 }
 
 impl RnnInputMode {

--- a/coaster-nn/src/frameworks/native/mod.rs
+++ b/coaster-nn/src/frameworks/native/mod.rs
@@ -97,7 +97,7 @@ impl<'a, T> NNOperationConfig<T> for helper::ConvolutionConfig where
     T: Add<T, Output = T> + Mul<T, Output = T> + Default + Copy
 {
 }
-impl<'a, T> ConvolutionConfig<T> for helper::ConvolutionConfig where
+impl<'a, T> ConvolutionContext<T> for helper::ConvolutionConfig where
     T: Add<T, Output = T> + Mul<T, Output = T> + Default + Copy
 {
 }
@@ -131,7 +131,7 @@ impl<T> Convolution<T> for Backend<Native>
 where
     T: Add<T, Output = T> + Mul<T, Output = T> + Default + Copy,
 {
-    fn new_convolution_config(
+    fn new_convolution_context(
         &self,
         src: &SharedTensor<T>,
         dest: &SharedTensor<T>,
@@ -174,8 +174,7 @@ where
         filter: &SharedTensor<T>,
         x: &SharedTensor<T>,
         result: &mut SharedTensor<T>,
-        _workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), Error> {
         let dev = self.device();
 
@@ -401,8 +400,8 @@ where
                 filter,
                 &filter_stride[..],
                 &filter_dim[..],
-                &config.padding[..],
-                &config.stride[..],
+                &context.padding[..],
+                &context.stride[..],
                 output,
                 &output_stride[1..],
                 &output_dim[1..],
@@ -418,8 +417,7 @@ where
         src_data: &SharedTensor<T>,
         dest_diff: &SharedTensor<T>,
         filter_diff: &mut SharedTensor<T>,
-        workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), Error> {
         unimplemented!()
     }
@@ -429,8 +427,7 @@ where
         filter: &SharedTensor<T>,
         x_diff: &SharedTensor<T>,
         result_diff: &mut SharedTensor<T>,
-        workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), Error> {
         unimplemented!()
     }

--- a/coaster-nn/src/plugin.rs
+++ b/coaster-nn/src/plugin.rs
@@ -139,13 +139,7 @@ pub trait NNOperationConfig<F> {}
 /// Provides Convolution Config functionality.
 ///
 /// Needs to be implemented for Operation specific configurations.
-pub trait ConvolutionConfig<F> {
-    /// Returns the largest workspace size in bytes needed
-    /// for any of the convolution operations.
-    fn workspace_size(&self) -> usize {
-        0
-    }
-}
+pub trait ConvolutionContext<F> {}
 
 /// Provides Rnn Config functionality.
 ///
@@ -161,7 +155,7 @@ pub trait RnnConfig<F> {
 /// Provides the functionality for a backend to support Neural Network related operations.
 pub trait NN<F> {
     /// The Convolution Operation Config representation for this Plugin.
-    type CC: NNOperationConfig<F> + ConvolutionConfig<F>;
+    type CC: NNOperationConfig<F> + ConvolutionContext<F>;
     /// The LRN Operation Config representation for this Plugin.
     type CLRN: NNOperationConfig<F>;
     /// The Pooling Operation Config representation for this Plugin.
@@ -548,7 +542,7 @@ pub enum MathType {
 pub trait Convolution<F>: NN<F> {
     /// Creates a new ConvolutionConfig, which needs to be passed to further
     /// convolution Operations.
-    fn new_convolution_config(
+    fn new_convolution_context(
         &self,
         src: &SharedTensor<F>,
         dest: &SharedTensor<F>,
@@ -569,8 +563,7 @@ pub trait Convolution<F>: NN<F> {
         filter: &SharedTensor<F>,
         x: &SharedTensor<F>,
         result: &mut SharedTensor<F>,
-        workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), crate::co::error::Error>;
 
     /// Computes the gradient of a [CNN convolution][convolution] with respect to the filter.
@@ -582,8 +575,7 @@ pub trait Convolution<F>: NN<F> {
         src_data: &SharedTensor<F>,
         dest_diff: &SharedTensor<F>,
         filter_diff: &mut SharedTensor<F>,
-        workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), crate::co::error::Error>;
 
     /// Computes the gradient of a [CNN convolution][convolution] over the input
@@ -596,8 +588,7 @@ pub trait Convolution<F>: NN<F> {
         filter: &SharedTensor<F>,
         x_diff: &SharedTensor<F>,
         result_diff: &mut SharedTensor<F>,
-        workspace: &mut SharedTensor<u8>,
-        config: &Self::CC,
+        context: &mut Self::CC,
     ) -> Result<(), crate::co::error::Error>;
 
     // /// Computes the backward Convolution function w.r.t the bias.

--- a/coaster-nn/src/tests/rnn.rs
+++ b/coaster-nn/src/tests/rnn.rs
@@ -3,9 +3,7 @@ use std::fmt;
 use co::prelude::*;
 use coaster as co;
 
-use crate::plugin::{
-    self, DirectionMode, RnnAlgorithm, RnnConfig, RnnInputMode, RnnNetworkMode, RnnPaddingMode,
-};
+use crate::plugin::{self, DirectionMode, RnnAlgorithm, RnnConfig, RnnInputMode, RnnNetworkMode};
 use crate::tests::{filled_tensor, uniformly_random_tensor, Epsilon, One, Zero};
 use crate::{co::plugin::numeric_helpers::Float, Rnn};
 


### PR DESCRIPTION
## What does this PR accomplish?

Refactor Convolution Coaster API and put workspace into ConvolutionConfig (which is renamed to ConvolutionContext).

Previously, workspace was opaque to the users of the API as they had to construct it and pass to API functions but had no use of it otherwise. And workspace is an internal details of CUDA as for example native implementation doesn't use it (although native implementation is currently incomplete).

This is in preparation for reimplementing the convolution layer in the new arch.

 * 🧭 Architecture

## Changes proposed by this PR:

* Rename ConvolutionConfig to ConvolutionContext.
* Put workspace into ConvolutionContext for CUDA and make CUDA impl manage it.

## Notes to reviewer:

Tests are not yet changed, I'll update them if you're OK with the overall idea.

Verified that `mnist conv` runs as before and converges to 95% accuracy.

## 📜 Checklist

 * [x] _All_ unit tests pass
 * [x] The `juice-examples` run just fine
