### PR TITLE
Now also saves bias layers

### DIFF
--- a/juice/src/layer.rs
+++ b/juice/src/layer.rs
@@ -933,7 +933,7 @@ impl<'a, B: IBackend> CapnpWrite<'a> for Layer<B> {
             let names = self.learnable_weights_names();
             let weights_data = self.learnable_weights_data();
 
-            assert_eq!(names.len(), weights_data.len(), "Not all layers are named");
+            assert_eq!(names.len(), weights_data.len(), "All layers must be named");
 
             for (i, (name, weight)) in names.iter().zip(weights_data).enumerate() {
                 let mut capnp_weight = weights.reborrow().get(i as u32);

--- a/juice/src/layer.rs
+++ b/juice/src/layer.rs
@@ -306,7 +306,15 @@ impl<B: IBackend> Layer<B> {
             } else {
                 format!("{}-{}", self.name, weight_id)
             };
+            
+            let display_name_bias = if !weight_name.is_empty() {
+                format!("{weight_name}-bias")
+            } else {
+                format!("{}-{}-bias", self.name, weight_id)
+            };
+
             self.weights_display_names.push(display_name.clone());
+            self.weights_display_names.push(display_name_bias.clone());
             // create name for registry
             let registry_name = format!("SHARED_WEIGHT_{}", display_name);
 
@@ -924,6 +932,8 @@ impl<'a, B: IBackend> CapnpWrite<'a> for Layer<B> {
                 .init_weights_data(self.learnable_weights_names().len() as u32);
             let names = self.learnable_weights_names();
             let weights_data = self.learnable_weights_data();
+
+            assert_eq!(names.len(), weights_data.len(), "Not all layers are named");
 
             for (i, (name, weight)) in names.iter().zip(weights_data).enumerate() {
                 let mut capnp_weight = weights.reborrow().get(i as u32);


### PR DESCRIPTION
<!--
Thank you for submitting a PR to juice!
-->

## What does this PR accomplish?
It saves bias layers along with ordinary weight layers, allowing models to be saved and loaded from disk.

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #188 .

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
I add another name to the list of names within a layer to account for the bias weights.

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [ ] Test coverage is excellent
 * [x] _All_ unit tests pass
 * [x] The `juice-examples` run just fine
 * [x] Documentation is thorough, extensive and explicit
