### PR TITLE
Simplify new_rnn_config() by only passing input size, not the full tensor

### DIFF
--- a/coaster-nn/src/frameworks/cuda/mod.rs
+++ b/coaster-nn/src/frameworks/cuda/mod.rs
@@ -860,7 +860,6 @@ where
 
     fn new_rnn_config(
         &self,
-        src: &SharedTensor<T>,
         dropout_probability: Option<f32>,
         dropout_seed: Option<u64>,
         sequence_length: i32,
@@ -868,6 +867,7 @@ where
         input_mode: RnnInputMode,
         direction_mode: DirectionMode,
         algorithm: RnnAlgorithm,
+        input_size: i32,
         hidden_size: i32,
         num_layers: i32,
         batch_size: i32,
@@ -877,7 +877,6 @@ where
         let network_mode = network_mode.as_cudnn()?;
         let algorithm = algorithm.as_cudnn()?;
 
-        let src_description = src.desc();
         let data_type = <T as DataTypeInfo>::cudnn_data_type();
 
         let drop_desc = exec2!(cudnn_framework.init_dropout(
@@ -889,7 +888,7 @@ where
 
         let x_desc = rnn_sequence_descriptors(
             sequence_length,
-            src_description[1] as i32,
+            input_size,
             hidden_size,
             batch_size,
             num_layers,

--- a/coaster-nn/src/frameworks/native/mod.rs
+++ b/coaster-nn/src/frameworks/native/mod.rs
@@ -868,7 +868,6 @@ where
 {
     fn new_rnn_config(
         &self,
-        src: &SharedTensor<T>,
         dropout_probability: Option<f32>,
         dropout_seed: Option<u64>,
         sequence_length: i32,
@@ -876,6 +875,7 @@ where
         input_mode: RnnInputMode,
         direction_mode: DirectionMode,
         algorithm: RnnAlgorithm,
+        input_size: i32,
         hidden_size: i32,
         num_layers: i32,
         batch_size: i32,

--- a/coaster-nn/src/plugin.rs
+++ b/coaster-nn/src/plugin.rs
@@ -311,7 +311,6 @@ pub trait Rnn<F>: NN<F> {
     /// Create a RnnConfig
     fn new_rnn_config(
         &self,
-        src: &SharedTensor<F>,
         dropout_probability: Option<f32>,
         dropout_seed: Option<u64>,
         sequence_length: i32,
@@ -319,6 +318,7 @@ pub trait Rnn<F>: NN<F> {
         input_mode: RnnInputMode,
         direction_mode: DirectionMode,
         algorithm: RnnAlgorithm,
+        input_size: i32,
         hidden_size: i32,
         num_layers: i32,
         batch_size: i32,

--- a/coaster-nn/src/tests/rnn.rs
+++ b/coaster-nn/src/tests/rnn.rs
@@ -40,7 +40,6 @@ where
 
     let rnn_config = backend
         .new_rnn_config(
-            &src,
             dropout_probability,
             dropout_seed,
             SEQUENCE_LENGTH as i32,
@@ -48,6 +47,7 @@ where
             input_mode,
             direction_mode,
             algorithm,
+            INPUT_SIZE as i32,
             HIDDEN_SIZE as i32,
             NUM_LAYERS as i32,
             BATCH_SIZE as i32,


### PR DESCRIPTION
## What does this PR accomplish?

 * 🪣 Misc

## Changes proposed by this PR:

Replace the `src` argument to `new_rnn_config()` with just scalar input size as it's the only information the function needs.

## Notes to reviewer:

This is in preparation for reimplementation of RNN layer in new arch.

## 📜 Checklist

 * [x] Test coverage is excellent
 * [x] _All_ unit tests pass
 * [x] The `juice-examples` run just fine
 * [x] Documentation is thorough, extensive and explicit
